### PR TITLE
Capture pad/backup-button times, Meet Division, citizenship, and team LSC

### DIFF
--- a/hytek_parser/hy3/_utils.py
+++ b/hytek_parser/hy3/_utils.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional, Union
 
 from hytek_parser._utils import safe_cast, select_from_enum
 from hytek_parser.hy3.enums import ReplacedTimeTimeCode
@@ -18,3 +18,15 @@ def parse_time(raw_time: str) -> Union[float, ReplacedTimeTimeCode]:
         return casted
     else:
         return select_from_enum(ReplacedTimeTimeCode, raw_time)
+
+
+def parse_time_or_none(raw_time: str) -> Optional[float]:
+    """Parse a timing field where 0.00/blank means 'not recorded'.
+
+    Unlike parse_time (which returns 0.0 for "0.00" and a ReplacedTimeTimeCode
+    for blank/non-numeric input), this returns None unless the value is a
+    positive float. Used for pad and backup-button times, where an unused
+    slot is written as 0.00 and should surface as None rather than 0.0.
+    """
+    val = parse_time(raw_time)
+    return val if isinstance(val, float) and val > 0.0 else None

--- a/hytek_parser/hy3/line_parsers/c_team_parsers.py
+++ b/hytek_parser/hy3/line_parsers/c_team_parsers.py
@@ -26,12 +26,24 @@ def c1_parser(
         # Then truncate to 5 chars
         team_code = "".join(TEAM_CODE_REGEX.findall(team_name.upper()))[:5]
 
-    # Issue #118 — LSC code at C1 cols 54-56 (e.g. 'NE', 'PC', 'CA'); populates
-    # the previously-unset Team.region field.
-    region = extract(line, 54, 3) or None
+    # Issue #118 — LSC code at C1 cols 54-55 (2 chars, e.g. 'NE', 'PC', 'CA');
+    # populates the previously-unset Team.region field.
+    # Bug fix: was extract(54, 3), which grabbed the first letter of the contact
+    # name at col 56, corrupting ~19% of teams' LSC codes.
+    region = extract(line, 54, 2) or None
+
+    # C1 contact name slots: cols 56-85 (contact_name_1) and 86-115 (contact_name_2).
+    # Often identical; blank slot → None.
+    contact_name_1 = extract(line, 56, 30) or None
+    contact_name_2 = extract(line, 86, 30) or None
 
     file.meet.get_or_create_team(
-        name=team_name, short_name=team_short_name, code=team_code, region=region
+        name=team_name,
+        short_name=team_short_name,
+        code=team_code,
+        region=region,
+        contact_name_1=contact_name_1,
+        contact_name_2=contact_name_2,
     )
     return file
 

--- a/hytek_parser/hy3/line_parsers/c_team_parsers.py
+++ b/hytek_parser/hy3/line_parsers/c_team_parsers.py
@@ -55,7 +55,11 @@ def c2_parser(
     # Get the last team
     team_code, team = file.meet.last_team
 
-    team.address_1 = extract(line, 3, 60)
+    # C2 has two 30-char address lines: line 1 (cols 3-32) is a free-text
+    # "c/o"/attention line (often a contact person, sometimes the org), line 2
+    # (cols 33-62) is the street. They were previously read as one 60-char blob.
+    team.address_1 = extract(line, 3, 30)
+    team.address_2 = extract(line, 33, 30)
     team.city = extract(line, 63, 30)
     team.state = extract(line, 93, 2)
     team.zip_code = extract(line, 95, 10)

--- a/hytek_parser/hy3/line_parsers/c_team_parsers.py
+++ b/hytek_parser/hy3/line_parsers/c_team_parsers.py
@@ -26,8 +26,12 @@ def c1_parser(
         # Then truncate to 5 chars
         team_code = "".join(TEAM_CODE_REGEX.findall(team_name.upper()))[:5]
 
+    # Issue #118 — LSC code at C1 cols 54-56 (e.g. 'NE', 'PC', 'CA'); populates
+    # the previously-unset Team.region field.
+    region = extract(line, 54, 3) or None
+
     file.meet.get_or_create_team(
-        name=team_name, short_name=team_short_name, code=team_code
+        name=team_name, short_name=team_short_name, code=team_code, region=region
     )
     return file
 
@@ -48,9 +52,6 @@ def c2_parser(
         team.country = team_country
     else:
         team.country = opts["default_country"]
-
-    # TODO: Team region
-    team.region = "Unknown"
 
     file.meet.last_team = (team_code, team)
     return file

--- a/hytek_parser/hy3/line_parsers/c_team_parsers.py
+++ b/hytek_parser/hy3/line_parsers/c_team_parsers.py
@@ -26,7 +26,7 @@ def c1_parser(
         # Then truncate to 5 chars
         team_code = "".join(TEAM_CODE_REGEX.findall(team_name.upper()))[:5]
 
-    # Issue #118 — LSC code at C1 cols 54-55 (2 chars, e.g. 'NE', 'PC', 'CA');
+    # LSC code at C1 cols 54-55 (2 chars, e.g. 'NE', 'PC', 'CA');
     # populates the previously-unset Team.region field.
     # Bug fix: was extract(54, 3), which grabbed the first letter of the contact
     # name at col 56, corrupting ~19% of teams' LSC codes.

--- a/hytek_parser/hy3/line_parsers/d_swimmer_parsers.py
+++ b/hytek_parser/hy3/line_parsers/d_swimmer_parsers.py
@@ -24,6 +24,12 @@ def d1_parser(
     swimmer.date_of_birth = date_or_none(extract(line, 89, 8))
     swimmer.age = int(extract(line, 97, 3))
 
+    # Issue #118 — previously dropped D1 fields. Capture both per spec.
+    # citizenship: cols 113-115 (3 chars). Observed: 'USA' or blank.
+    # unparsed_d1_col_125: col 125 (1 char). Observed: 'N' or blank; semantics unverified.
+    swimmer.citizenship = extract(line, 113, 3) or None
+    swimmer.unparsed_d1_col_125 = extract(line, 125, 1) or None
+
     swimmer.team_code = team_code
 
     file.meet.add_swimmer(swimmer)

--- a/hytek_parser/hy3/line_parsers/d_swimmer_parsers.py
+++ b/hytek_parser/hy3/line_parsers/d_swimmer_parsers.py
@@ -24,7 +24,7 @@ def d1_parser(
     swimmer.date_of_birth = date_or_none(extract(line, 89, 8))
     swimmer.age = int(extract(line, 97, 3))
 
-    # Issue #118 — previously dropped D1 fields. Capture both per spec.
+    # previously dropped D1 fields. Capture both per spec.
     # citizenship: cols 113-115 (3 chars). Observed: 'USA' or blank.
     # unparsed_d1_col_125: col 125 (1 char). Observed: 'N' or blank; semantics unverified.
     swimmer.citizenship = extract(line, 113, 3) or None

--- a/hytek_parser/hy3/line_parsers/e_event_parsers.py
+++ b/hytek_parser/hy3/line_parsers/e_event_parsers.py
@@ -105,7 +105,7 @@ def e2_parser(
     heat_place = safe_cast(int, extract(line, 27, 3))
     overall_place = safe_cast(int, extract(line, 30, 4))
 
-    # Issue #118 — previously-dropped E2 timing fields.
+    # previously-dropped E2 timing fields.
     # See spec for column-offset derivation and failure-mode evidence
     # (touchpad turn-touch misattribution in short SCY sprints).
     # parse_time_or_none returns None for "0.00" and blank/non-numeric fields.

--- a/hytek_parser/hy3/line_parsers/e_event_parsers.py
+++ b/hytek_parser/hy3/line_parsers/e_event_parsers.py
@@ -105,7 +105,21 @@ def e2_parser(
     heat_place = safe_cast(int, extract(line, 27, 3))
     overall_place = safe_cast(int, extract(line, 30, 4))
 
-    # Skipping over pad/plunger times since they are not that useful
+    # Issue #118 — previously-dropped E2 timing fields.
+    # See spec for column-offset derivation and failure-mode evidence
+    # (touchpad turn-touch misattribution in short SCY sprints).
+    # parse_time returns 0.0 for "0.00" fields, which we treat as absent → None.
+    def _timing_or_none(raw: str):
+        val = parse_time(raw)
+        return None if val == 0.0 else val
+
+    pad_time      = _timing_or_none(extract(line, 63, 12))
+    button_1_time = _timing_or_none(extract(line, 39, 8))
+    button_2_time = _timing_or_none(extract(line, 47, 8))
+    button_3_time = _timing_or_none(extract(line, 55, 8))
+    backup_4_time = _timing_or_none(extract(line, 75, 8))
+    alt_time_code = extract(line, 96, 1) or None  # observed: 'A' / 'K' / blank
+
     raw_date = extract(line, 88, 8).strip()
     date_ = datetime.strptime(raw_date, "%m%d%Y").date() if raw_date else None
 
@@ -133,6 +147,12 @@ def e2_parser(
     setattr(entry, f"{prefix}_heat_place", heat_place)
     setattr(entry, f"{prefix}_overall_place", overall_place)
     setattr(entry, f"{prefix}_date", date_)
+    setattr(entry, f"{prefix}_pad_time", pad_time)
+    setattr(entry, f"{prefix}_button_1_time", button_1_time)
+    setattr(entry, f"{prefix}_button_2_time", button_2_time)
+    setattr(entry, f"{prefix}_button_3_time", button_3_time)
+    setattr(entry, f"{prefix}_backup_4_time", backup_4_time)
+    setattr(entry, f"{prefix}_alt_time_code", alt_time_code)
 
     event.last_entry = entry
     file.meet.last_event = (event_num, event)

--- a/hytek_parser/hy3/line_parsers/e_event_parsers.py
+++ b/hytek_parser/hy3/line_parsers/e_event_parsers.py
@@ -63,9 +63,9 @@ def e1_parser(
     entry_converted_seed_time = parse_time(extract(line, 43, 8))
     entry_converted_seed_time_course = event.course
 
-    # Issue #118 — Meet Division at cols 77-79.
-    # 'JV'/'VR'/'A'/'AA'/'AAA'/'BB'/numeric. See schema for value notes.
-    meet_division = extract(line, 77, 3) or None
+    # Meet Division: col 77-79 in most MM versions, col 92-93 in MM4/MM5-7.0Fa.
+    # The two are mutually exclusive; col 77 takes precedence.
+    meet_division = extract(line, 77, 3) or extract(line, 92, 2) or None
 
     event.get_or_create_entry(
         swimmers=entry_swimmers,

--- a/hytek_parser/hy3/line_parsers/e_event_parsers.py
+++ b/hytek_parser/hy3/line_parsers/e_event_parsers.py
@@ -63,6 +63,10 @@ def e1_parser(
     entry_converted_seed_time = parse_time(extract(line, 43, 8))
     entry_converted_seed_time_course = event.course
 
+    # Issue #118 — previously dropped E1 field at cols 77-79.
+    # Observed values: VR, JV, SLV. Semantics unverified.
+    unparsed_e1_col_77_79 = extract(line, 77, 3) or None
+
     event.get_or_create_entry(
         swimmers=entry_swimmers,
         relay=False,
@@ -71,6 +75,7 @@ def e1_parser(
         seed_course=entry_seed_course,
         converted_seed_time=entry_converted_seed_time,
         converted_seed_time_course=entry_converted_seed_time_course,
+        unparsed_e1_col_77_79=unparsed_e1_col_77_79,
     )
 
     # Update event

--- a/hytek_parser/hy3/line_parsers/e_event_parsers.py
+++ b/hytek_parser/hy3/line_parsers/e_event_parsers.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any
 
 from hytek_parser._utils import extract, get_age_group, safe_cast, select_from_enum
-from hytek_parser.hy3._utils import parse_time
+from hytek_parser.hy3._utils import parse_time, parse_time_or_none
 from hytek_parser.hy3.enums import (
     Course,
     DisqualificationCode,
@@ -108,16 +108,12 @@ def e2_parser(
     # Issue #118 — previously-dropped E2 timing fields.
     # See spec for column-offset derivation and failure-mode evidence
     # (touchpad turn-touch misattribution in short SCY sprints).
-    # parse_time returns 0.0 for "0.00" fields, which we treat as absent → None.
-    def _timing_or_none(raw: str):
-        val = parse_time(raw)
-        return None if val == 0.0 else val
-
-    pad_time      = _timing_or_none(extract(line, 63, 12))
-    button_1_time = _timing_or_none(extract(line, 39, 8))
-    button_2_time = _timing_or_none(extract(line, 47, 8))
-    button_3_time = _timing_or_none(extract(line, 55, 8))
-    backup_4_time = _timing_or_none(extract(line, 75, 8))
+    # parse_time_or_none returns None for "0.00" and blank/non-numeric fields.
+    pad_time      = parse_time_or_none(extract(line, 63, 12))
+    button_1_time = parse_time_or_none(extract(line, 39, 8))
+    button_2_time = parse_time_or_none(extract(line, 47, 8))
+    button_3_time = parse_time_or_none(extract(line, 55, 8))
+    backup_4_time = parse_time_or_none(extract(line, 75, 8))
     alt_time_code = extract(line, 96, 1) or None  # observed: 'A' / 'K' / blank
 
     raw_date = extract(line, 88, 8).strip()

--- a/hytek_parser/hy3/line_parsers/e_event_parsers.py
+++ b/hytek_parser/hy3/line_parsers/e_event_parsers.py
@@ -63,9 +63,9 @@ def e1_parser(
     entry_converted_seed_time = parse_time(extract(line, 43, 8))
     entry_converted_seed_time_course = event.course
 
-    # Issue #118 — previously dropped E1 field at cols 77-79.
-    # Observed values: VR, JV, SLV. Semantics unverified.
-    unparsed_e1_col_77_79 = extract(line, 77, 3) or None
+    # Issue #118 — Meet Division at cols 77-79.
+    # 'JV'/'VR'/'A'/'AA'/'AAA'/'BB'/numeric. See schema for value notes.
+    meet_division = extract(line, 77, 3) or None
 
     event.get_or_create_entry(
         swimmers=entry_swimmers,
@@ -75,7 +75,7 @@ def e1_parser(
         seed_course=entry_seed_course,
         converted_seed_time=entry_converted_seed_time,
         converted_seed_time_course=entry_converted_seed_time_course,
-        unparsed_e1_col_77_79=unparsed_e1_col_77_79,
+        meet_division=meet_division,
     )
 
     # Update event

--- a/hytek_parser/hy3/line_parsers/f_relay_parsers.py
+++ b/hytek_parser/hy3/line_parsers/f_relay_parsers.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any
 
 from hytek_parser._utils import extract, get_age_group, safe_cast, select_from_enum
-from hytek_parser.hy3._utils import parse_time
+from hytek_parser.hy3._utils import parse_time, parse_time_or_none
 from hytek_parser.hy3.enums import (
     Course,
     DisqualificationCode,
@@ -107,7 +107,17 @@ def f2_parser(
     heat_place = safe_cast(int, extract(line, 27, 3))
     overall_place = safe_cast(int, extract(line, 30, 4))
 
-    # Skipping over pad/plunger times since they are not that useful
+    # Issue #118 — previously-dropped F2 timing fields. The five timing-column
+    # offsets are IDENTICAL to e2_parser; only alt_time_code differs because F2
+    # has a 15-column gap before its date field (date at col 103, not 88).
+    # F2 alt_time_code lives at col 111, not col 96.
+    pad_time      = parse_time_or_none(extract(line, 63, 12))
+    button_1_time = parse_time_or_none(extract(line, 39, 8))
+    button_2_time = parse_time_or_none(extract(line, 47, 8))
+    button_3_time = parse_time_or_none(extract(line, 55, 8))
+    backup_4_time = parse_time_or_none(extract(line, 75, 8))
+    alt_time_code = extract(line, 111, 1) or None  # F2 offset; observed: 'A'/'K'/blank
+
     raw_date = extract(line, 103, 8).strip()
     date_ = datetime.strptime(raw_date, "%m%d%Y").date() if raw_date else None
 
@@ -135,6 +145,12 @@ def f2_parser(
     setattr(entry, f"{prefix}_heat_place", heat_place)
     setattr(entry, f"{prefix}_overall_place", overall_place)
     setattr(entry, f"{prefix}_date", date_)
+    setattr(entry, f"{prefix}_pad_time", pad_time)
+    setattr(entry, f"{prefix}_button_1_time", button_1_time)
+    setattr(entry, f"{prefix}_button_2_time", button_2_time)
+    setattr(entry, f"{prefix}_button_3_time", button_3_time)
+    setattr(entry, f"{prefix}_backup_4_time", backup_4_time)
+    setattr(entry, f"{prefix}_alt_time_code", alt_time_code)
 
     event.last_entry = entry
     file.meet.last_event = (event_num, event)

--- a/hytek_parser/hy3/line_parsers/f_relay_parsers.py
+++ b/hytek_parser/hy3/line_parsers/f_relay_parsers.py
@@ -107,7 +107,7 @@ def f2_parser(
     heat_place = safe_cast(int, extract(line, 27, 3))
     overall_place = safe_cast(int, extract(line, 30, 4))
 
-    # Issue #118 — previously-dropped F2 timing fields. The five timing-column
+    # previously-dropped F2 timing fields. The five timing-column
     # offsets are IDENTICAL to e2_parser; only alt_time_code differs because F2
     # has a 15-column gap before its date field (date at col 103, not 88).
     # F2 alt_time_code lives at col 111, not col 96.

--- a/hytek_parser/hy3/schemas.py
+++ b/hytek_parser/hy3/schemas.py
@@ -157,10 +157,11 @@ class EventEntry:
     relay_team_id: Optional[str] = None
     relay_swim_team_code: Optional[str] = None
 
-    # Issue #118 — E1 Meet Division (cols 77-79).
-    # Values: 'JV' (Junior Varsity), 'VR' (Varsity), classification codes
-    # ('A'/'AA'/'AAA'/'BB'/...), or numeric ('0'/'1'/'2'/'3'). '0' is the
-    # most common numeric and likely means 'no division'.
+    # Issue #118 — Meet Division. The host-configured division label for the
+    # entry: 'JV'/'VR' (varsity-style), classification codes ('A'/'AA'/'AAA'/'BB'),
+    # HS enrollment classes ('5A'/'4A'/'3A'), age-group/level codes ('AG'/'SR'),
+    # or numeric ('0'/'1'/'2'/'3'). Stored at cols 77-79 in most MM versions,
+    # cols 92-93 in MM4/MM5-7.0Fa (read with col-77 precedence).
     meet_division: Optional[str] = None
 
     def __init__(

--- a/hytek_parser/hy3/schemas.py
+++ b/hytek_parser/hy3/schemas.py
@@ -157,10 +157,11 @@ class EventEntry:
     relay_team_id: Optional[str] = None
     relay_swim_team_code: Optional[str] = None
 
-    # Issue #118 — E1 field previously dropped (cols 77-79).
-    # Observed values: 'VR', 'JV', 'SLV'. Semantics unverified —
-    # name intentionally non-descriptive.
-    unparsed_e1_col_77_79: Optional[str] = None
+    # Issue #118 — E1 Meet Division (cols 77-79).
+    # Values: 'JV' (Junior Varsity), 'VR' (Varsity), classification codes
+    # ('A'/'AA'/'AAA'/'BB'/...), or numeric ('0'/'1'/'2'/'3'). '0' is the
+    # most common numeric and likely means 'no division'.
+    meet_division: Optional[str] = None
 
     def __init__(
         self,
@@ -173,7 +174,7 @@ class EventEntry:
         converted_seed_time_course: Course,
         relay_team_id: Optional[str] = None,
         relay_swim_team_code: Optional[str] = None,
-        unparsed_e1_col_77_79: Optional[str] = None,   # <-- NEW (Issue #118)
+        meet_division: Optional[str] = None,
     ) -> None:
         self.swimmers = swimmers
         self.relay = relay
@@ -184,7 +185,7 @@ class EventEntry:
         self.converted_seed_time_course = converted_seed_time_course
         self.relay_team_id = relay_team_id
         self.relay_swim_team_code = relay_swim_team_code
-        self.unparsed_e1_col_77_79 = unparsed_e1_col_77_79
+        self.meet_division = meet_division
 
         for course in ("prelim", "swimoff", "finals"):
             setattr(self, f"{course}_time", None)
@@ -272,7 +273,7 @@ class Event:
         converted_seed_time_course: Course,
         relay_team_id: Optional[str] = None,
         relay_swim_team_code: Optional[str] = None,
-        unparsed_e1_col_77_79: Optional[str] = None,   # <-- NEW (Issue #118)
+        meet_division: Optional[str] = None,
     ) -> EventEntry:
         """Get an event entry or create one if needed."""
         entry = EventEntry(
@@ -285,7 +286,7 @@ class Event:
             converted_seed_time_course=converted_seed_time_course,
             relay_team_id=relay_team_id,
             relay_swim_team_code=relay_swim_team_code,
-            unparsed_e1_col_77_79=unparsed_e1_col_77_79,   # <-- NEW
+            meet_division=meet_division,
         )
         if self.entries and self.entries[-1].same_swimmer_entry_as(entry):
             # P/F entries always listed together: a swimmer (individuals) or a

--- a/hytek_parser/hy3/schemas.py
+++ b/hytek_parser/hy3/schemas.py
@@ -104,6 +104,14 @@ class EventEntry:
     prelim_heat_place: Optional[int] = None
     prelim_overall_place: Optional[int] = None
     prelim_date: Optional[date] = None
+    # Issue #118 — E2 fields previously dropped (pad + 3 buttons + backup_4 + alt code)
+    prelim_pad_time: Optional[float] = None
+    prelim_button_1_time: Optional[float] = None
+    prelim_button_2_time: Optional[float] = None
+    prelim_button_3_time: Optional[float] = None
+    prelim_backup_4_time: Optional[float] = None
+    # col 96; semantics unverified — observed 'A'/'K'/blank
+    prelim_alt_time_code: Optional[str] = None
 
     # Swimoff Time info
     swimoff_time: Optional[Union[float, ReplacedTimeTimeCode]] = None
@@ -116,6 +124,14 @@ class EventEntry:
     swimoff_heat_place: Optional[int] = None
     swimoff_overall_place: Optional[int] = None
     swimoff_date: Optional[date] = None
+    # Issue #118 — E2 fields previously dropped (pad + 3 buttons + backup_4 + alt code)
+    swimoff_pad_time: Optional[float] = None
+    swimoff_button_1_time: Optional[float] = None
+    swimoff_button_2_time: Optional[float] = None
+    swimoff_button_3_time: Optional[float] = None
+    swimoff_backup_4_time: Optional[float] = None
+    # col 96; semantics unverified — observed 'A'/'K'/blank
+    swimoff_alt_time_code: Optional[str] = None
 
     # Finals time info
     finals_time: Optional[Union[float, ReplacedTimeTimeCode]] = None
@@ -128,10 +144,23 @@ class EventEntry:
     finals_heat_place: Optional[int] = None
     finals_overall_place: Optional[int] = None
     finals_date: Optional[date] = None
+    # Issue #118 — E2 fields previously dropped (pad + 3 buttons + backup_4 + alt code)
+    finals_pad_time: Optional[float] = None
+    finals_button_1_time: Optional[float] = None
+    finals_button_2_time: Optional[float] = None
+    finals_button_3_time: Optional[float] = None
+    finals_backup_4_time: Optional[float] = None
+    # col 96; semantics unverified — observed 'A'/'K'/blank
+    finals_alt_time_code: Optional[str] = None
 
     # Relay attribution (moved from Event — set by f1_parser)
     relay_team_id: Optional[str] = None
     relay_swim_team_code: Optional[str] = None
+
+    # Issue #118 — E1 field previously dropped (cols 77-79).
+    # Observed values: 'VR', 'JV', 'SLV'. Semantics unverified —
+    # name intentionally non-descriptive.
+    unparsed_e1_col_77_79: Optional[str] = None
 
     def __init__(
         self,
@@ -166,10 +195,17 @@ class EventEntry:
             setattr(self, f"{course}_heat_place", None)
             setattr(self, f"{course}_overall_place", None)
             setattr(self, f"{course}_date", None)
+            setattr(self, f"{course}_pad_time", None)
+            setattr(self, f"{course}_button_1_time", None)
+            setattr(self, f"{course}_button_2_time", None)
+            setattr(self, f"{course}_button_3_time", None)
+            setattr(self, f"{course}_backup_4_time", None)
+            setattr(self, f"{course}_alt_time_code", None)
 
         self.prelim_dq_info = None
         self.swimoff_dq_info = None
         self.finals_dq_info = None
+        self.unparsed_e1_col_77_79 = None
 
     def same_swimmer_entry_as(self, other: "EventEntry") -> bool:
         """Check if two entries are the same entry (so prelim+finals merge).

--- a/hytek_parser/hy3/schemas.py
+++ b/hytek_parser/hy3/schemas.py
@@ -58,7 +58,7 @@ class Team:
     state: str
     zip_code: str
     country: str
-    region: str
+    region: Optional[str]
 
     # Contact info
     daytime_phone: str
@@ -351,7 +351,7 @@ class Meet:
             self.swimmers[swimmer.meet_id] = swimmer
             self.teams[swimmer.team_code].swimmers[swimmer.meet_id] = swimmer
 
-    def get_or_create_team(self, name: str, short_name: str, code: str) -> Team:
+    def get_or_create_team(self, name: str, short_name: str, code: str, region: Optional[str] = None) -> Team:
         """Get a team or create if needed."""
         if team := self.teams.get(code):
             return team
@@ -364,7 +364,7 @@ class Meet:
                 address_2="N/A",
                 city="N/A",
                 country="N/A",
-                region="N/A",
+                region=region,
                 state="N/A",
                 zip_code="N/A",
                 daytime_phone="N/A",

--- a/hytek_parser/hy3/schemas.py
+++ b/hytek_parser/hy3/schemas.py
@@ -36,7 +36,7 @@ class Swimmer:
     usa_swimming_id: str
     team_code: str  # Team 5-letter code
 
-    # Issue #118 — D1 fields previously dropped by the parser
+    # D1 fields previously dropped by the parser
     citizenship: Optional[str] = None
     # col 125; semantics unverified — name intentionally non-descriptive
     unparsed_d1_col_125: Optional[str] = None
@@ -106,7 +106,7 @@ class EventEntry:
     prelim_heat_place: Optional[int] = None
     prelim_overall_place: Optional[int] = None
     prelim_date: Optional[date] = None
-    # Issue #118 — E2 fields previously dropped (pad + 3 buttons + backup_4 + alt code)
+    # E2 fields previously dropped (pad + 3 buttons + backup_4 + alt code)
     prelim_pad_time: Optional[float] = None
     prelim_button_1_time: Optional[float] = None
     prelim_button_2_time: Optional[float] = None
@@ -126,7 +126,7 @@ class EventEntry:
     swimoff_heat_place: Optional[int] = None
     swimoff_overall_place: Optional[int] = None
     swimoff_date: Optional[date] = None
-    # Issue #118 — E2 fields previously dropped (pad + 3 buttons + backup_4 + alt code)
+    # E2 fields previously dropped (pad + 3 buttons + backup_4 + alt code)
     swimoff_pad_time: Optional[float] = None
     swimoff_button_1_time: Optional[float] = None
     swimoff_button_2_time: Optional[float] = None
@@ -146,7 +146,7 @@ class EventEntry:
     finals_heat_place: Optional[int] = None
     finals_overall_place: Optional[int] = None
     finals_date: Optional[date] = None
-    # Issue #118 — E2 fields previously dropped (pad + 3 buttons + backup_4 + alt code)
+    # E2 fields previously dropped (pad + 3 buttons + backup_4 + alt code)
     finals_pad_time: Optional[float] = None
     finals_button_1_time: Optional[float] = None
     finals_button_2_time: Optional[float] = None
@@ -159,7 +159,7 @@ class EventEntry:
     relay_team_id: Optional[str] = None
     relay_swim_team_code: Optional[str] = None
 
-    # Issue #118 — Meet Division. The host-configured division label for the
+    # Meet Division. The host-configured division label for the
     # entry: 'JV'/'VR' (varsity-style), classification codes ('A'/'AA'/'AAA'/'BB'),
     # HS enrollment classes ('5A'/'4A'/'3A'), age-group/level codes ('AG'/'SR'),
     # or numeric ('0'/'1'/'2'/'3'). Stored at cols 77-79 in most MM versions,

--- a/hytek_parser/hy3/schemas.py
+++ b/hytek_parser/hy3/schemas.py
@@ -65,6 +65,8 @@ class Team:
     evening_phone: str
     fax: str
     email: str
+    contact_name_1: Optional[str] = None
+    contact_name_2: Optional[str] = None
 
     # Swimmers
     swimmers: dict[int, Swimmer] = Factory(dict)
@@ -352,7 +354,15 @@ class Meet:
             self.swimmers[swimmer.meet_id] = swimmer
             self.teams[swimmer.team_code].swimmers[swimmer.meet_id] = swimmer
 
-    def get_or_create_team(self, name: str, short_name: str, code: str, region: Optional[str] = None) -> Team:
+    def get_or_create_team(
+        self,
+        name: str,
+        short_name: str,
+        code: str,
+        region: Optional[str] = None,
+        contact_name_1: Optional[str] = None,
+        contact_name_2: Optional[str] = None,
+    ) -> Team:
         """Get a team or create if needed."""
         if team := self.teams.get(code):
             return team
@@ -372,6 +382,8 @@ class Meet:
                 evening_phone="N/A",
                 fax="N/A",
                 email="N/A",
+                contact_name_1=contact_name_1,
+                contact_name_2=contact_name_2,
             )
 
             # Add team, this also updates the teams dict

--- a/hytek_parser/hy3/schemas.py
+++ b/hytek_parser/hy3/schemas.py
@@ -36,6 +36,11 @@ class Swimmer:
     usa_swimming_id: str
     team_code: str  # Team 5-letter code
 
+    # Issue #118 — D1 fields previously dropped by the parser
+    citizenship: Optional[str] = None
+    # col 125; semantics unverified — name intentionally non-descriptive
+    unparsed_d1_col_125: Optional[str] = None
+
 
 @define
 class Team:

--- a/hytek_parser/hy3/schemas.py
+++ b/hytek_parser/hy3/schemas.py
@@ -173,6 +173,7 @@ class EventEntry:
         converted_seed_time_course: Course,
         relay_team_id: Optional[str] = None,
         relay_swim_team_code: Optional[str] = None,
+        unparsed_e1_col_77_79: Optional[str] = None,   # <-- NEW (Issue #118)
     ) -> None:
         self.swimmers = swimmers
         self.relay = relay
@@ -183,6 +184,7 @@ class EventEntry:
         self.converted_seed_time_course = converted_seed_time_course
         self.relay_team_id = relay_team_id
         self.relay_swim_team_code = relay_swim_team_code
+        self.unparsed_e1_col_77_79 = unparsed_e1_col_77_79
 
         for course in ("prelim", "swimoff", "finals"):
             setattr(self, f"{course}_time", None)
@@ -205,7 +207,6 @@ class EventEntry:
         self.prelim_dq_info = None
         self.swimoff_dq_info = None
         self.finals_dq_info = None
-        self.unparsed_e1_col_77_79 = None
 
     def same_swimmer_entry_as(self, other: "EventEntry") -> bool:
         """Check if two entries are the same entry (so prelim+finals merge).
@@ -271,6 +272,7 @@ class Event:
         converted_seed_time_course: Course,
         relay_team_id: Optional[str] = None,
         relay_swim_team_code: Optional[str] = None,
+        unparsed_e1_col_77_79: Optional[str] = None,   # <-- NEW (Issue #118)
     ) -> EventEntry:
         """Get an event entry or create one if needed."""
         entry = EventEntry(
@@ -283,6 +285,7 @@ class Event:
             converted_seed_time_course=converted_seed_time_course,
             relay_team_id=relay_team_id,
             relay_swim_team_code=relay_swim_team_code,
+            unparsed_e1_col_77_79=unparsed_e1_col_77_79,   # <-- NEW
         )
         if self.entries and self.entries[-1].same_swimmer_entry_as(entry):
             # P/F entries always listed together: a swimmer (individuals) or a

--- a/tests/hy3/fixtures/README.md
+++ b/tests/hy3/fixtures/README.md
@@ -14,18 +14,20 @@ from publicly distributed meet results:
 | `mm3_3_0ea_individuals_blank_date.hy3` | MM3 3.0Ea | 2011 CA CSSC Fall Mile | Bug 1 on a different MM generation |
 | `mm5_8_0fd_relay_alternates.hy3` | MM5 8.0Fd | 2025 WMPSSDL Championships | Bug 2-B (F3 swimmer dict preserves leg numbers for alternates) |
 | `mm4_ymca_col92_division_citizenship.hy3` | MM4 4.0Ec | 2013 YMCA Nationals Short Course (Virginia Swimming) | Issue #118: E1 col-92 `meet_division` (`SW`); D1 `citizenship` (`USA`); C1 `region` (NE/MD/NI); E2 pad+button timing; F2 relay pad+button timing |
-| `mm_col77_division.hy3` | MM5 6.0Cc | 2015 State/Non-State Open 25 yd (Wisconsin Swimming) | Issue #118: E1 col-77 `meet_division` (`JV`); E2 `alt_time_code` (`A`, `K`); pad-vs-button divergence (pad=107.39 vs btn1=102.49) |
+| `mm_col77_division.hy3` | MM5 6.0Cc | 2015 State/Non-State Open 25 yd (Wisconsin Swimming) | Issue #118: E1 col-77 `meet_division` (`JV`); E2 `alt_time_code` (`A`, `K`); pad-vs-button divergence (pad=107.39 vs btn1=102.49); C1 `region` (`WI`) |
 | `mm_pad_button_divergence.hy3` | MM5 8.0Fd | 2025 MT HOT Tropical Meet (Montana Swimming) | Issue #118: clear pad-vs-button divergence (pad=36.26 vs result=75.29, half-pool touchpad); E2 `alt_time_code` (`A`); two LSC regions (MT, WY) |
 
 ## Redaction
 
-The following D1 and C2/C3 fields were replaced with placeholders of the
+The following D1, C1, and C2/C3 fields were replaced with placeholders of the
 same column width so the files remain parseable:
 
 - `D1` last_name → `Swimmer<meet_id>`
 - `D1` first_name → `Test`
 - `D1` nick_name, middle_initial, usa_swimming_id → blank
 - `D1` date_of_birth → `01011970`
+- `C1` contact_name_1 (cols 56-85) → `Test Contact` padded to 30 chars, or blank if original was blank
+- `C1` contact_name_2 (cols 86-115) → `Test Contact` padded to 30 chars, or blank if original was blank
 - `C2` address_1, city, zip_code → blank (state and country retained)
 - `C3` daytime_phone, evening_phone, fax, email → blank
 

--- a/tests/hy3/fixtures/README.md
+++ b/tests/hy3/fixtures/README.md
@@ -13,6 +13,9 @@ from publicly distributed meet results:
 | `mm2_2_0fg_relay_multi_team.hy3` | MM2 2.0Fg | 2007 Pacific Committee R-W SC Meet | Bug 1 (blank E2/F2 date column) + Bug 2-A (multi-team relay attribution) |
 | `mm3_3_0ea_individuals_blank_date.hy3` | MM3 3.0Ea | 2011 CA CSSC Fall Mile | Bug 1 on a different MM generation |
 | `mm5_8_0fd_relay_alternates.hy3` | MM5 8.0Fd | 2025 WMPSSDL Championships | Bug 2-B (F3 swimmer dict preserves leg numbers for alternates) |
+| `mm4_ymca_col92_division_citizenship.hy3` | MM4 4.0Ec | 2013 YMCA Nationals Short Course (Virginia Swimming) | Issue #118: E1 col-92 `meet_division` (`SW`); D1 `citizenship` (`USA`); C1 `region` (NE/MD/NI); E2 pad+button timing; F2 relay pad+button timing |
+| `mm_col77_division.hy3` | MM5 6.0Cc | 2015 State/Non-State Open 25 yd (Wisconsin Swimming) | Issue #118: E1 col-77 `meet_division` (`JV`); E2 `alt_time_code` (`A`, `K`); pad-vs-button divergence (pad=107.39 vs btn1=102.49) |
+| `mm_pad_button_divergence.hy3` | MM5 8.0Fd | 2025 MT HOT Tropical Meet (Montana Swimming) | Issue #118: clear pad-vs-button divergence (pad=36.26 vs result=75.29, half-pool touchpad); E2 `alt_time_code` (`A`); two LSC regions (MT, WY) |
 
 ## Redaction
 
@@ -28,6 +31,13 @@ same column width so the files remain parseable:
 
 Team codes, team names, meet name, facility, and event metadata are
 intact — these are public information from the original meet results.
+
+## Coverage gaps (known)
+
+`backup_4_time` (E2 col 75-82) is always zero in the three issue-#118 source meets;
+no real file with a non-zero value was found among the designated sources. The field
+is exercised by the line-parser-level tests in `test_e_event_parsers.py` but is not
+covered by any integration fixture.
 
 ## Bug references
 

--- a/tests/hy3/fixtures/README.md
+++ b/tests/hy3/fixtures/README.md
@@ -13,9 +13,9 @@ from publicly distributed meet results:
 | `mm2_2_0fg_relay_multi_team.hy3` | MM2 2.0Fg | 2007 Pacific Committee R-W SC Meet | Bug 1 (blank E2/F2 date column) + Bug 2-A (multi-team relay attribution) |
 | `mm3_3_0ea_individuals_blank_date.hy3` | MM3 3.0Ea | 2011 CA CSSC Fall Mile | Bug 1 on a different MM generation |
 | `mm5_8_0fd_relay_alternates.hy3` | MM5 8.0Fd | 2025 WMPSSDL Championships | Bug 2-B (F3 swimmer dict preserves leg numbers for alternates) |
-| `mm4_ymca_col92_division_citizenship.hy3` | MM4 4.0Ec | 2013 YMCA Nationals Short Course (Virginia Swimming) | Issue #118: E1 col-92 `meet_division` (`SW`); D1 `citizenship` (`USA`); C1 `region` (NE/MD/NI); E2 pad+button timing; F2 relay pad+button timing |
-| `mm_col77_division.hy3` | MM5 6.0Cc | 2015 State/Non-State Open 25 yd (Wisconsin Swimming) | Issue #118: E1 col-77 `meet_division` (`JV`); E2 `alt_time_code` (`A`, `K`); pad-vs-button divergence (pad=107.39 vs btn1=102.49); C1 `region` (`WI`) |
-| `mm_pad_button_divergence.hy3` | MM5 8.0Fd | 2025 MT HOT Tropical Meet (Montana Swimming) | Issue #118: clear pad-vs-button divergence (pad=36.26 vs result=75.29, half-pool touchpad); E2 `alt_time_code` (`A`); two LSC regions (MT, WY) |
+| `mm4_ymca_col92_division_citizenship.hy3` | MM4 4.0Ec | 2013 YMCA Nationals Short Course (Virginia Swimming) | E1 col-92 `meet_division` (`SW`); D1 `citizenship` (`USA`); C1 `region` (NE/MD/NI); E2 pad+button timing; F2 relay pad+button timing |
+| `mm_col77_division.hy3` | MM5 6.0Cc | 2015 State/Non-State Open 25 yd (Wisconsin Swimming) | E1 col-77 `meet_division` (`JV`); E2 `alt_time_code` (`A`, `K`); pad-vs-button divergence (pad=107.39 vs btn1=102.49); C1 `region` (`WI`) |
+| `mm_pad_button_divergence.hy3` | MM5 8.0Fd | 2025 MT HOT Tropical Meet (Montana Swimming) | clear pad-vs-button divergence (pad=36.26 vs result=75.29, half-pool touchpad); E2 `alt_time_code` (`A`); two LSC regions (MT, WY) |
 
 ## Redaction
 
@@ -36,7 +36,7 @@ intact — these are public information from the original meet results.
 
 ## Coverage gaps (known)
 
-`backup_4_time` (E2 col 75-82) is always zero in the three issue-#118 source meets;
+`backup_4_time` (E2 col 75-82) is always zero in the three source meets;
 no real file with a non-zero value was found among the designated sources. The field
 is exercised by the line-parser-level tests in `test_e_event_parsers.py` but is not
 covered by any integration fixture.

--- a/tests/hy3/fixtures/mm2_2_0fg_relay_multi_team.hy3
+++ b/tests/hy3/fixtures/mm2_2_0fg_relay_multi_team.hy3
@@ -22,7 +22,7 @@ E2F    0.00YR      0  3  2  0   0  0    0.00    0.00    0.00         0.00     0.
 F1BRSC A   0FFG   200E  9 10  0S  5.00 21     0.00     0.00     0.00    0.00  0NN               N                               57
 F2F  195.89YQ66    0  1  5  0   0  0  195.89  195.84  195.92       195.89     0.00                                        0     07
 F3F  517MoskoF1F  514CampbF2F  525SchecF3F  535NeapoF4                                                                          14
-C1COLA City Of Los Angeles                           CAJ. Rosas/S. Steward           M. Beaird/J.Rosas/S. Stewart     0  0      87
+C1COLA City Of Los Angeles                           CATest Contact                  Test Contact                     0  0      87
 C2                                                                                          CA          USA                     39
 C3                                                                                                                              83
 D1F  465Swimmer465          Test                                                     42701011970  9     0       USA             77
@@ -37,7 +37,7 @@ E2F   94.18Y       0  5  7  4  13  0   94.15   94.43   94.18        94.18     0.
 D1M  467Swimmer467          Test                                                     42901011970  9     0       USA             86
 E1M  467VazquMB   100E  9 10  0S  2.75  2   101.94Y  101.94Y   13.00    0.00  2NN               N                               40
 E2F   98.46Y       0  3  1  5   6  0   98.42   98.56   98.46        98.46     0.00                                        0     85
-C1LAC  Los Angeles County                            CANICOLAS OROZCO                                                 0  0      93
+C1LAC  Los Angeles County                            CATest Contact                                                   0  0      93
 D1F  330Swimmer330          Test                                                     29201011970  9     0                       61
 E1F  330BaronFG   100E  9 10  0S  2.75  1    88.54Y   88.54Y   17.00    0.00  1NN               N                               00
 E2F   83.67Y       0  6  6  2   2  0   83.87   83.67   83.64        83.67     0.00                                        0     85
@@ -56,7 +56,7 @@ E2F   89.41Y       0  6  5  6   7  0   89.41   89.34   89.41        89.41     0.
 F1LAC  A   0FFG   200E  9 10  0S  5.00 21   172.33Y  172.33Y   40.00    0.00  0NN               N                               68
 F2F  166.81Y       0  1  4  1   1  0  166.81  166.88  166.78       166.81     0.00                                        0     36
 F3F  308SaineF1F  320LemusF2F  330BaronF3F  329ContrF4                                                                          34
-C1LASC Los Angeles Swim Club                         CATim Sharpe                    Darlene Bible                    0  0      21
+C1LASC Los Angeles Swim Club                         CATest Contact                  Test Contact                     0  0      21
 C2                                                                                          CA          USA                     32
 D1M  281Swimmer281          Test                                                     24301011970  9     0       USA             95
 E1M  281BadgeMB   100E  9 10  0S  2.75  2   108.27Y  108.27Y    7.00    0.00  2NN               N                               99
@@ -82,7 +82,7 @@ E2F  145.72YQ3E    0  1  2  0   0  0  145.72  145.70  145.73       145.72     0.
 D1F  556Swimmer556          Test                                                     51801011970 10     0                       92
 E1F  556ShereFG   100E  9 10  0S  2.75  1     0.00Y    0.00Y    0.00    0.00  2NN               N                               49
 E2F  114.04Y       0  1  5  1  22  0  114.04  113.91  114.07       114.04     0.00                                        0     06
-C1PALY Palisades Malibu YMCA                         CABrian Timmerman               Eric Butler                      0  0      03
+C1PALY Palisades Malibu YMCA                         CATest Contact                  Test Contact                     0  0      03
 C2                                                                                          CA          USA                     41
 D1M   86Swimmer86           Test                                                      8601011970 10     0                       53
 E1M   86KirshMB   100E  9 10  0S  2.75  2   114.16Y  114.16Y    9.00    0.00  2NN               N                               00
@@ -93,7 +93,7 @@ E2F  100.49Y       0  2  2  1   9  0  100.49  100.47  100.60       100.49     0.
 D1M   88Swimmer88           Test                                                      8801011970 10     0                       43
 E1M   88Saab MB   100E  9 10  0S  2.75  2    97.74Y   97.74Y   17.00    0.00  2NN               N                               59
 E2F   95.66Y       0  3  4  2   2  0   95.69   95.66   95.66        95.66     0.00                                        0     85
-C1PVAC Palos Verdes Aquatic Club                     CAEric                          Vianey                           0  0      67
+C1PVAC Palos Verdes Aquatic Club                     CATest Contact                  Test Contact                     0  0      67
 C2                                                                                          CA          USA                     00
 C3                                                                                                                              92
 D1F  346Swimmer346          Test                                                     30801011970 10     0                       51
@@ -141,7 +141,7 @@ F3F  228Shi  F1F  233KhineF2F  224MonteF3F  223King F4                          
 F1ROSE B   0FFG   200E  9 10  0S  5.00 21     0.00     0.00     0.00    0.00  0NN               N                               57
 F2F  196.17YQ66    0  1  2  0   0  0  196.33  196.17  196.15       196.17     0.00                                        0     76
 F3F  237Woo  F1F  240HalleF2F  238HoffmF3F  258ArrevF4                                                                          33
-C1RYL  Royal Swim Team                               CAVal Bagri                                                      0  0      32
+C1RYL  Royal Swim Team                               CATest Contact                                                   0  0      32
 C2                                                                                          CA          USA                     07
 C3                                                                                                                              46
 D1M    4Swimmer4            Test                                                       401011970 10     0                       80
@@ -150,13 +150,13 @@ E2F   95.32Y       0  4  8  5   1  0   95.32   95.37   95.28        95.32     0.
 D1M   17Swimmer17           Test                                                      1701011970 10     0                       42
 E1M   17StarkMB   100E  9 10  0S  2.75  2   104.77Y  104.77Y   14.00    0.00  1NN               N                               30
 E2F   91.96Y       0  2  4  1   5  0   91.96   91.92   92.17        91.96     0.00                                        0     75
-C1TORR Swim Torrance                                 CADiane Graner - Gallas         Jamie Contis                     0  0      91
+C1TORR Swim Torrance                                 CATest Contact                  Test Contact                     0  0      91
 C2                                                                                          CA          USA                     25
 C3                                                                                                                              56
 D1F  564Swimmer564          Test                                                     52501011970 10     0                       91
 E1F  564MorgaFG   100E  9 10  0S  2.75  1   105.98Y  105.98Y    6.00    0.00  1NN               N                               10
 E2F   92.65Y       0  4  2  1  11  0   92.65   92.48   92.65        92.65     0.00                                        0     85
-C1TSM  Team Santa Monica                             CARachel Stratton               Jon Carroll                      0  0      21
+C1TSM  Team Santa Monica                             CATest Contact                  Test Contact                     0  0      21
 C2                                                                                          CA          USA                     44
 C3                                                                                                                              09
 D1F  501Swimmer501          Test                                                     46301011970  9     0                       00
@@ -170,7 +170,7 @@ C2                                                                              
 D1F  299Swimmer299          Test                                                     26101011970 10     0                       83
 E1F  299SrivaFG   100E  9 10  0S  2.75  1     0.00Y    0.00Y    0.00    0.00  2NN               N                               59
 E2F  105.27YQ2Q    0  2  7  0   0  0  105.58    0.00  104.97       105.27     0.00                                        0     36
-C1WEST Westchester YMCA Orcas                        CAJennifer Fusco                Gaku Ito                         0  0      21
+C1WEST Westchester YMCA Orcas                        CATest Contact                  Test Contact                     0  0      21
 C2                                                                                          CA          USA                     16
 C3                                                                                                                              41
 D1M  157Swimmer157          Test                                                     12801011970  9     0                       31
@@ -211,7 +211,7 @@ F3F  178Pei  F1F  159PrentF2F  154GarciF3F  180Lima F4                          
 F1WEST B   0FFG   200E  9 10  0S  5.00 21     0.00     0.00     0.00    0.00  0NN               N                               67
 F2F  214.80YQ66    0  1  7  0   0  0  214.98  214.80  214.76       214.80     0.00                                        0     66
 F3F  193KaczoF1F  165FundeF2F  179SioriF3F  198MavroF4                                                                          64
-C1WSTA Westside Aquatics                             CAAdam Blakis                   Adam Balkis                      0  0      79
+C1WSTA Westside Aquatics                             CATest Contact                  Test Contact                     0  0      79
 C2                                                                                          CA          USA                     17
 C3                                                                                                                              61
 D1F   29Swimmer29           Test                                                      2901011970 10     0                       63
@@ -220,7 +220,7 @@ E2F  103.00YQ3D    0  2  1  0   0  0  102.93  103.00  103.02       103.00     0.
 D1M  506Swimmer506          Test                                                     46801011970 10     0                       92
 E1M  506KoffmMB   100E  9 10  0S  2.75  2    89.96Y   89.96Y   15.00    0.00  1NN               N                               30
 E2F   91.09Y       0  4  3  4   4  0   91.16   91.09   91.09        91.09     0.00                                        0     65
-C1ZAP  Zenith Aquatic Program                        CADeAnne Preyer                 Sharilyn Twidwell                0  0      65
+C1ZAP  Zenith Aquatic Program                        CATest Contact                  Test Contact                     0  0      65
 C2                                                                                          CA          USA                     27
 C3                                                                                                                              60
 D1F  399Swimmer399          Test                                                     36101011970 10     0                       94

--- a/tests/hy3/fixtures/mm4_ymca_col92_division_citizenship.hy3
+++ b/tests/hy3/fixtures/mm4_ymca_col92_division_citizenship.hy3
@@ -1,0 +1,32 @@
+A107Results From MM to TM    Hy-Tek, Ltd    MM4 4.0Ec     04072013  8:24 PMYMCA National SC, LC, & Masters Champs               99
+B12013 YMCA Nationals Short Course             Greensbor Aquatic Complex                    040320130406201304032013   0        17
+B22013  National YMCA Short Course             Greensboro NC                                010105Y1 15.00  USA-S NC 13051AP    02
+C1ANA  Andover/North Andover YMCA    Andover-MA      NE                                                               0  0      27
+C2                                                                                          MA                                  62
+D1F 1906Swimmer1906         Test                                                     39301011970 18     0       USA             22
+E1F 1906CammaFW    50A  0109 13S 10.00101    24.56Y   24.56Y    0.00    0.00   NN          SW   N                               11
+E2P   24.63Y       0 18  6  5 108  0   24.68   24.67    0.00        24.63     0.00     04032013                                 76
+D1F 1904Swimmer1904         Test                                                     39101011970 16     0       USA             72
+E1F 1904LennoFW   200A  0109 13S 10.00201   114.59Y  114.59Y    0.00    0.00   NN          SW   N                               61
+E2P  115.49Y       0  7  8  1  78  0  115.43  115.45    0.00       115.49     0.00 0.0004042013                                 47
+D1F 1903Swimmer1903         Test                                                     39001011970 16     0       USA             97
+E1F 1903RussoFW    50A  0109 13S 10.00101    24.95Y   24.95Y    0.00    0.00   NN          SW   N                               51
+E2P   25.06Y       0  5  8  4 173  0   25.00   24.98    0.00        25.06     0.00     04032013                                 46
+D1F 1905Swimmer1905         Test                                                     39201011970 13     0       USA             61
+E1F 1905Ty   FW   100B  0109 13S 10.00105    58.95Y   58.95Y    0.00    0.00   NN          SW   N                               20
+E2P   60.67Y       0 11  2  6 150  0   60.60   60.54    0.00        60.67     0.00 0.0004032013                                 07
+F1ANA  A   0FFW   200E  0109 13S 40.00109   112.00Y  112.00Y    0.00    0.00   NN   4      SW   NA                              10
+F2P  111.38Y       0  2  6  3  56  0  111.33  111.36    0.00       111.38     0.00 0.00 +0.0 +0.0 +0.004032013                  48
+G1P 2   27.54P 4   58.97P 6   86.27P 8  111.38                                                                                  94
+F3F 1906CammaP1F 1905Ty   P2F 1903RussoP3F 1904LennoP4                                                                          63
+C1SPY  Anne Arundel County YMCA      Anne Arundel-MD MD                                                               0  0      57
+C2                                                                                          MD          USA                     69
+D1F 1893Swimmer1893         Test                                                     38001011970 16     0       USA             94
+E1F 1893AtkinFW   100D  0109 13S 10.00205    59.31Y   59.31Y    0.00    0.00   NN          SW   N                               41
+E2P   59.56Y       0  4  2  5 130  0   59.51   59.42    0.00        59.56     0.00 0.0004042013                                 07
+G1P 2   27.65P 4   59.56                                                                                                        52
+C1AYST Auburn YMCA-WEIU              Auburn-NY       NI                                                               0  0      61
+C2                                                                                          NY          USA                     62
+D1F 2298Swimmer2298         Test                                                     78501011970 15     0                       41
+E1F 2298D'ArrFW    50A  0109 13A 10.00141    26.05Y   26.05Y    0.00    0.00   NN          SW  TN                               80
+E2F   26.17Y       0  7  8  7 130  0   26.24    0.00    0.00        26.17     0.00 0.0004032013                           0     76

--- a/tests/hy3/fixtures/mm5_8_0fd_relay_alternates.hy3
+++ b/tests/hy3/fixtures/mm5_8_0fd_relay_alternates.hy3
@@ -1,7 +1,7 @@
 A107Results From MM to TM    Hy-Tek, Ltd    MM5 8.0Fd     02032025  9:00 AMPotomac Valley Swimming - For Office Use Only License78
 B1WMPSSDL Championships 2025                   EPPLEY CENTER AT UMD                         013120250201202501312025   0        87
 B2                                                                                          010103Y1  7.00                      71
-C1BI   Bishop Ireton High School     Bishop Ireton   VAKaitllyn McNutt               Kaitllyn McNutt                  0  0      03
+C1BI   Bishop Ireton High School     Bishop Ireton   VATest Contact                  Test Contact                     0  0      03
 C2                                                                                          VA          USA                     58
 C3                                                                                                                              46
 D1M  460Swimmer460          Test                                                     46001011970  0SR   0                   N   20
@@ -60,7 +60,7 @@ F1DJO  B   0MMB   200A  0109  0S 30.00 17    97.72Y   97.72Y    0.00    0.00   N
 F2P   98.82Y   X   0  5  1  0   0  0   98.82   98.88    0.00        98.82     0.00                    01312025                  07
 G1P 2   24.30P 4   48.98P 6   74.78P 8   98.82                                                                                  94
 F3M  113BraveP1M   87MilleP2M  121SayboP3M  118MilliP4                                                                          64
-C1BU   Bullis School                 Bullis          PVErica Woda                    Erica Woda                       0  0      09
+C1BU   Bullis School                 Bullis          PVTest Contact                  Test Contact                     0  0      09
 C2                                                                                          MD          USA                     16
 C3                                                                                                                              73
 D1M  575Swimmer575          Test                                                     57501011970 16JR   0                   N   51
@@ -83,7 +83,7 @@ F1BU   B   0MMB   200A  0109  0S 30.00 17   107.83Y  107.83Y    0.00    0.00   N
 F2P  108.24Y   X   0  2  7  0   0  0  108.23  108.33    0.00       108.24     0.00                    01312025                  17
 G1P 2   24.41P 4   50.54P 6   86.22P 8  108.24                                                                                  84
 F3M  563BhandP2M  573HussaP3M  578Li   P4                                                                                       69
-C1DEM  DeMatha Catholic High School  DeMatha           Tom Krawczewicz               Tom Krawczewicz                  0  0      01
+C1DEM  DeMatha Catholic High School  DeMatha           Test Contact                  Test Contact                     0  0      01
 C2                                                                                          MD          USA                     23
 C3                                                                                                                              52
 D1M  444Swimmer444          Test                                                     44401011970 15SO   0                   N   79
@@ -143,7 +143,7 @@ F1GDS  A   0MMB   200A  0109  0S 30.00 17   109.43Y  109.43Y   12.00    0.00   N
 F2P  108.00Y       0  2  8  3  20  0  108.03    0.00  107.98       108.00     0.00                    01312025                  86
 G1P 2   27.23P 4   54.22P 6   81.16P 8  108.00                                                                                  74
 F3M  554Li   P1M  551HirshP2M  547KeeleP3M  553HolleP4                                                                          33
-C1PREP GEORGETOWN PREPARATORY SCHOOL GEORGETOWN PREP   Rick Robinson                 Rick Robinson                    0  0      17
+C1PREP GEORGETOWN PREPARATORY SCHOOL GEORGETOWN PREP   Test Contact                  Test Contact                     0  0      17
 C2                                                                                          MD          USA                     39
 C3                                                                                                                              74
 D1M  621Swimmer621          Test                                                     62101011970 15SO   0                   N   94
@@ -166,7 +166,7 @@ F1PREP B   0MMB   200A  0109  0S 30.00 17    99.93Y   99.93Y    0.00    0.00   N
 F2P   96.09Y   X   0  5  8  0   0  0   96.08    0.00   96.05        96.09     0.00                    01312025                  96
 G1P 2   24.49P 4   48.20P 6   72.08P 8   96.09                                                                                  84
 F3M  612GeoghP1M  621AndreP2M  625BedesP3M  615EsqueP4                                                                          34
-C1GONZ Gonzaga College High School   Gonzaga         MDKevin Wagman                  Kevin Wagman                     0  0      68
+C1GONZ Gonzaga College High School   Gonzaga         MDTest Contact                  Test Contact                     0  0      68
 C2                                                                                          DC          USA                     90
 C3                                                                                                                              19
 D1M  159Swimmer159          Test                                                     15901011970  0SO   0                   N   01
@@ -216,7 +216,7 @@ F1LS   B   0MMB   200A  0109  0S 30.00 17   113.25Y  113.25Y    0.00    0.00   N
 F2P  110.79Y   X   0  1  6  0   0  0  110.82  110.81    0.00       110.79     0.00                    01312025                  17
 G1P 2   25.71P 4   50.62P 6   81.60P 8  110.79                                                                                  84
 F3M  718Shao P1M  743LaPlaP2M  737HanikP3M  740ReisfP4                                                                          04
-C1MAR  MARET SCHOOL                  FROGS           PVCrosby Treadwell              Crosby Treadwell                 0  0      02
+C1MAR  MARET SCHOOL                  FROGS           PVTest Contact                  Test Contact                     0  0      02
 C2                                                                                          DC          USA                     67
 D1M  210Swimmer210          Test                                                     21001011970  0     0                   N   11
 D1M  200Swimmer200          Test                                                     20001011970 17SR   0                   N   70
@@ -226,7 +226,7 @@ F1MAR  A   0MMB   200A  0109  0S 30.00 17   106.81Y  106.81Y    0.00    0.00   N
 F2P    0.00YR      0  2  2  0   0  0    0.00    0.00    0.00         0.00     0.00                    01312025                  45
 G1P 2    0.00P 4    0.00P 6    0.00P 8    0.00                                                                                  83
 F3M  210SchesP1M  208VandiP2M  201TekleP3M  200SisleP4                                                                          64
-C1GC   Our Lady of Good Counsel      Good Counsel      Beth Silva                    Beth Silva                       0  0      34
+C1GC   Our Lady of Good Counsel      Good Counsel      Test Contact                  Test Contact                     0  0      34
 C2                                                                                          MD          USA                     51
 D1M  272Swimmer272          Test                                                     27201011970 18SR   0                   N   29
 D1M  341Swimmer341          Test                                                     34101011970  0SR   0                   N   88
@@ -286,7 +286,7 @@ F1SMR  A   0MMB   200A  0109  0S 30.00 17    98.21Y   98.21Y   24.00    0.00   N
 F2P   99.07Y       0  4  1  6  16  0   99.04   99.11    0.00        99.07     0.00                    01312025                  56
 G1P 2   24.31P 4   49.38P 6   74.04P 8   99.07                                                                                  84
 F3M   24ThompP1M   23ThompP2M   15MagnoP3M   21smithP4                                                                          74
-C1SID  Sidwell Friends School                          Megan Farrell                 Megan Farrell                    0  0      53
+C1SID  Sidwell Friends School                          Test Contact                  Test Contact                     0  0      53
 C2                                                                                          DC                                  89
 C3                                                                                                                              71
 D1M  356Swimmer356          Test                                                     35601011970 14FR   0                   N   76
@@ -304,7 +304,7 @@ F3M  357Iimi P1M  347SiMa P2M  356Guo  P3M  346JiminP4                          
 F1SID  B   0MMB   200A  0109  0S 30.00 17   105.11Y  105.11Y    0.00    0.00   NN  X4           NB                              79
 F2P    0.00YR  X   0  2  6  0   0  0    0.00    0.00    0.00         0.00     0.00                    01312025                  06
 G1P 2    0.00P 4    0.00P 6    0.00P 8    0.00                                                                                  83
-C1STA  St. Albans School                               Richard Bettencourt           Richard Bettencourt              0  0      76
+C1STA  St. Albans School                               Test Contact                  Test Contact                     0  0      76
 C2                                                                                          DC                                  01
 C3                                                                                                                              60
 D1M  523Swimmer523          Test                                                     52301011970 1527   0                   N   09
@@ -342,7 +342,7 @@ F1SAES A   0MMB   200A  0109  0S 30.00 17   102.19Y  102.19Y    0.00    0.00   N
 F2P   97.87Y       0  2  4  1  15  0   97.82   97.97    0.00        97.87     0.00                    01312025                  76
 G1P 2   25.27P 4   49.72P 6   74.71P 8   97.87                                                                                  94
 F3M   66WalthP1M   53AroraP2M   65SweenP3M   62PortnP4                                                                          54
-C1SJC  St. John's College High SchoolSJC             PVLucy McHale                   Lucy McHale                      0  0      53
+C1SJC  St. John's College High SchoolSJC             PVTest Contact                  Test Contact                     0  0      53
 C2                                                                                          DC          USA                     40
 C3                                                                                                                              92
 D1M  393Swimmer393          Test                                                     39301011970 15SO   0                   N   31
@@ -388,7 +388,7 @@ F1PVI  B   0MMB   200A  0109  0S 30.00 17   110.53Y  110.53Y    0.00    0.00   N
 F2P  106.85Y   X   0  1  4  0   0  0  106.80  107.09    0.00       106.85     0.00                    01312025                  27
 G1P 2   24.92P 4   63.94P 6   82.63P 8  106.85                                                                                  94
 F3M  232HeislP1M  218PutchP2M  216HarviP3M  219RommeP4                                                                          94
-C1SSSA St. Stephen's & St. Agnes                     VAEvan Stiles                   Evan Stiles                      0  0      31
+C1SSSA St. Stephen's & St. Agnes                     VATest Contact                  Test Contact                     0  0      31
 C2                                                                                          VA          USA                     51
 C3                                                                                                                              99
 D1M  259Swimmer259          Test                                                     25901011970  0SO   0                   N   97
@@ -411,7 +411,7 @@ F1SSSA B   0MMB   200A  0109  0S 30.00 17   115.92Y  115.92Y    0.00    0.00   N
 F2P  115.41Y   X   0  1  1  0   0  0  115.53  115.47    0.00       115.41     0.00                    01312025                  17
 G1P 2   28.31P 4   55.74P 6   85.46P 8  115.41                                                                                  84
 F3M  263RiedyP1M  260ClarkP2M  261LiebeP3M  267SokolP4                                                                          64
-C1HTSHSThe Heights School            The Heights     MDMichael James                 Michael James                    0  0      67
+C1HTSHSThe Heights School            The Heights     MDTest Contact                  Test Contact                     0  0      67
 C2                                                                                          MD          USA                     94
 C3                                                                                                                              63
 D1M  145Swimmer145          Test                                                     14501011970  0SR   0                   N   67

--- a/tests/hy3/fixtures/mm_col77_division.hy3
+++ b/tests/hy3/fixtures/mm_col77_division.hy3
@@ -1,0 +1,18 @@
+A107Results From MM to TM    Hy-Tek, Ltd    MM5 6.0Cc     11082015  5:38 PMWaukesha Express Swim Team                           18
+B12015 State/Non-State Open (25 yd.)           Waukesha South High School                   110820151108201511082015   0        65
+B2Nov 8th 2015 State/Non-State Open (25 Yd.)   Waukesha South High School                   010601Y1  5.00  WI2015-             67
+C1BB   BERLIN BARRACUDA SWIM TEAM                    WIPHIL SASS                     PHIL SASS                        0  0      43
+C2                                                                                          WI                                  32
+C3                                                                                                                              06
+D1M 5570Swimmer5570         Test                                                     41901011970 11     0       USA         N   81
+E1M 5570FritzMB   100B  0109  0S  4.00 52   104.05Y  104.05Y    4.00    0.00   NN               N                               50
+E2F  102.54Y       0  2  8  5  13  0  102.49    0.00    0.00       107.39     0.00     11082015A                          0     96
+D1M 5564Swimmer5564         Test                                                     41301011970 14     0       USA         N   64
+E1M 5564NeubaMB   200E 13 14  0S  4.00 32   171.94Y  171.94Y   14.00    0.00JV NN               N                               31
+E2F  161.36Y       0  1  6  1   5  0  161.34    0.00  161.40       161.36     0.00     11082015                           0     66
+D1F 5563Swimmer5563         Test                                                     41201011970 13     0       USA         N   96
+E1F 5563SonneFG   200E 13 14  0S  4.00 31   165.74Y  165.74Y   14.00    0.00JV NN               N                               41
+E2F  156.28Y       0  4  7  1   5  0    0.00  156.17    0.00       156.28     0.00     11082015                           0     56
+E1F 5563SonneFG   100C 13 14  0S  4.00 41    89.72Y   89.72Y    3.00    0.00JV NN               N                               01
+E2F   89.75Y       0  3  2  5  14  0    0.00   69.80    0.00        89.75     0.00     11082015K                          0     76
+G1F 2   42.43F 4   89.75                                                                                                        32

--- a/tests/hy3/fixtures/mm_col77_division.hy3
+++ b/tests/hy3/fixtures/mm_col77_division.hy3
@@ -1,7 +1,7 @@
 A107Results From MM to TM    Hy-Tek, Ltd    MM5 6.0Cc     11082015  5:38 PMWaukesha Express Swim Team                           18
 B12015 State/Non-State Open (25 yd.)           Waukesha South High School                   110820151108201511082015   0        65
 B2Nov 8th 2015 State/Non-State Open (25 Yd.)   Waukesha South High School                   010601Y1  5.00  WI2015-             67
-C1BB   BERLIN BARRACUDA SWIM TEAM                    WIPHIL SASS                     PHIL SASS                        0  0      43
+C1BB   BERLIN BARRACUDA SWIM TEAM                    WITest Contact                  Test Contact                     0  0      43
 C2                                                                                          WI                                  32
 C3                                                                                                                              06
 D1M 5570Swimmer5570         Test                                                     41901011970 11     0       USA         N   81

--- a/tests/hy3/fixtures/mm_pad_button_divergence.hy3
+++ b/tests/hy3/fixtures/mm_pad_button_divergence.hy3
@@ -1,0 +1,15 @@
+A107Results From MM to TM    Hy-Tek, Ltd    MM5 8.0Fd     01122025  9:35 PMMontana Swimming                                     14
+B12025 MT HOT Tropical Meet                    Hardin Community Activity Center             0112202501122025011220252907        56
+B22025 MT HOT Tropical Meet                    Hardin Community Activity Center 25Y Pool, Ha010101Y1 20.00  2515                78
+C1BAC  Billings Aquatic Club Stingray                MT                                                               0  0      84
+C2                                                                                          MT                                  58
+D1F  175Swimmer175          Test                                                     14401011970 11     0       USA         N   53
+E1F  175AnderFW   100A 11 12  0S  3.00  1E   74.66Y   74.66Y    7.00    0.00   NN               N                               20
+E2F   75.29Y       0 10  7  4  10  0   75.29    0.00   75.32        36.26     0.00     01122025A                          0     96
+E1F  175AnderFW    50D 11 12  0S  3.00  5E   37.65Y   37.65Y   15.00    0.00   NN               N                               30
+E2F   36.50Y       0  8  2  5   4  0   36.54    0.00    0.00        36.50     0.00     01122025                           0     06
+C1SST  Sheridan Swim Team                            WY                                                               0  0      99
+C2                                                                                          WY                                  38
+D1M   94Swimmer94           Test                                                      6301011970 11     0       USA         N   85
+E1M   94AguirMM   100D 11 12  0S  3.00 13F   81.05Y   81.05Y   20.00    0.00   NN               N                               40
+E2F   78.76Y       0  3  5  1   1  0   78.71    0.00    0.00        78.76     0.00     01122025                           0     16

--- a/tests/hy3/line_parsers/test_c_team_parsers.py
+++ b/tests/hy3/line_parsers/test_c_team_parsers.py
@@ -1,6 +1,6 @@
 import unittest
 from hytek_parser.hy3.schemas import ParsedHytekFile, Meet
-from hytek_parser.hy3.line_parsers.c_team_parsers import c1_parser
+from hytek_parser.hy3.line_parsers.c_team_parsers import c1_parser, c2_parser
 
 
 # Helper to build a deterministic 130-char C1 line from parts.
@@ -132,3 +132,48 @@ class TestC1ContactNames(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# C2 layout (1-based cols): 1-2 "C2"; 3-32 address line 1 (30); 33-62 address
+# line 2 (30); 63-92 city (30); 93-94 state (2); 95-104 zip (10); 105-107 country.
+def _make_c2(line1="", line2="", city="", state="", zip_="", country="USA") -> str:
+    line = (
+        "C2"
+        + line1.ljust(30)[:30]
+        + line2.ljust(30)[:30]
+        + city.ljust(30)[:30]
+        + state.ljust(2)[:2]
+        + zip_.ljust(10)[:10]
+        + country.ljust(3)[:3]
+    )
+    return line.ljust(130)[:130]
+
+
+class TestC2AddressTwoLines(unittest.TestCase):
+    """C2 has two 30-char address lines; previously merged into one 60-char field."""
+
+    def _file_with_team(self):
+        file = ParsedHytekFile()
+        file.meet = Meet()
+        file.meet.last_team = c1_parser(_make_c1(code="WAVE", lsc="CA"), file, {"default_country": "USA"}).meet.last_team
+        return file, {"default_country": "USA"}
+
+    def test_address_split_into_two_lines(self):
+        file, opts = self._file_with_team()
+        c2 = _make_c2(line1="Jim Warren", line2="23119 Mariano Street",
+                      city="Woodland Hills", state="CA", zip_="91367")
+        self.assertEqual(130, len(c2))
+        file = c2_parser(c2, file, opts)
+        _, team = file.meet.last_team
+        self.assertEqual("Jim Warren", team.address_1)            # line 1 (c/o name) — NOT merged
+        self.assertEqual("23119 Mariano Street", team.address_2)  # line 2 (street)
+        self.assertEqual("Woodland Hills", team.city)
+        self.assertEqual("91367", team.zip_code)
+
+    def test_blank_line1_yields_empty(self):
+        file, opts = self._file_with_team()
+        c2 = _make_c2(line1="", line2="500 Pool Rd", city="Town", state="CA", zip_="90001")
+        file = c2_parser(c2, file, opts)
+        _, team = file.meet.last_team
+        self.assertEqual("", team.address_1)
+        self.assertEqual("500 Pool Rd", team.address_2)

--- a/tests/hy3/line_parsers/test_c_team_parsers.py
+++ b/tests/hy3/line_parsers/test_c_team_parsers.py
@@ -40,7 +40,7 @@ def _make_c1(
 
 
 class TestC1TeamRegion(unittest.TestCase):
-    """Issue #118 — populate Team.region from the C1 LSC code at cols 54-55."""
+    """populate Team.region from the C1 LSC code at cols 54-55."""
 
     def _file(self):
         file = ParsedHytekFile()

--- a/tests/hy3/line_parsers/test_c_team_parsers.py
+++ b/tests/hy3/line_parsers/test_c_team_parsers.py
@@ -3,8 +3,44 @@ from hytek_parser.hy3.schemas import ParsedHytekFile, Meet
 from hytek_parser.hy3.line_parsers.c_team_parsers import c1_parser
 
 
+# Helper to build a deterministic 130-char C1 line from parts.
+# Layout (1-based cols):
+#   1-2   prefix  "C1"
+#   3-7   code    5 chars
+#   8-37  name    30 chars
+#  38-53  short   16 chars
+#  54-55  lsc     2 chars
+#  56-85  c1      30 chars  (contact_name_1)
+#  86-115 c2      30 chars  (contact_name_2)
+# 116-128 flags   13 chars
+# 129-130 chk     2 chars
+def _make_c1(
+    code: str = "TESTC",
+    name: str = "Test Team",
+    short: str = "Test Short",
+    lsc: str = "NE",
+    contact1: str = "",
+    contact2: str = "",
+    flags: str = "0  0         ",
+    chk: str = "27",
+) -> str:
+    line = (
+        "C1"
+        + code.ljust(5)[:5]
+        + name.ljust(30)[:30]
+        + short.ljust(16)[:16]
+        + lsc.ljust(2)[:2]
+        + contact1.ljust(30)[:30]
+        + contact2.ljust(30)[:30]
+        + flags.ljust(13)[:13]
+        + chk.ljust(2)[:2]
+    )
+    assert len(line) == 130, f"line length {len(line)} != 130"
+    return line
+
+
 class TestC1TeamRegion(unittest.TestCase):
-    """Issue #118 — populate Team.region from the C1 LSC code at cols 54-56."""
+    """Issue #118 — populate Team.region from the C1 LSC code at cols 54-55."""
 
     def _file(self):
         file = ParsedHytekFile()
@@ -13,7 +49,8 @@ class TestC1TeamRegion(unittest.TestCase):
 
     def test_c1_region_from_col_54(self):
         file, opts = self._file()
-        # Real C1 shape: code(3-7), name(8-37), short(38-53), LSC(54-56).
+        # Real C1 shape: code(3-7), name(8-37), short(38-53), LSC(54-55).
+        # LSC has trailing spaces so 2-char or 3-char extraction both work here.
         c1 = "C1ANA  Andover/North Andover YMCA    Andover-MA      NE                                                               0  0      27"
         self.assertEqual(130, len(c1))
         file = c1_parser(c1, file, opts)
@@ -29,6 +66,68 @@ class TestC1TeamRegion(unittest.TestCase):
         file = c1_parser(c1, file, opts)
         _, team = file.meet.last_team
         self.assertIsNone(team.region)
+
+    def test_c1_region_width_regression(self):
+        """Regression: LSC must be exactly 2 chars; contact name at col 56 must NOT bleed in.
+
+        With extract(54, 3) the region becomes e.g. 'NED' (first letter of
+        'David McCrary').  With the correct extract(54, 2) it is 'NE'.
+        """
+        file, opts = self._file()
+        c1 = _make_c1(lsc="NE", contact1="David McCrary")
+        self.assertEqual(130, len(c1))
+        file = c1_parser(c1, file, opts)
+        _, team = file.meet.last_team
+        # Must be exactly 2 chars — NOT 'NED'
+        self.assertEqual("NE", team.region)
+
+
+class TestC1ContactNames(unittest.TestCase):
+    """C1 cols 56-85 / 86-115 → Team.contact_name_1 / contact_name_2."""
+
+    def _file(self):
+        file = ParsedHytekFile()
+        file.meet = Meet()
+        return file, {"default_country": "USA"}
+
+    def test_contact_name_1_populated(self):
+        file, opts = self._file()
+        c1 = _make_c1(contact1="Test Contact")
+        file = c1_parser(c1, file, opts)
+        _, team = file.meet.last_team
+        self.assertEqual("Test Contact", team.contact_name_1)
+
+    def test_contact_name_2_populated(self):
+        file, opts = self._file()
+        c1 = _make_c1(contact1="Test Contact", contact2="Another Person")
+        file = c1_parser(c1, file, opts)
+        _, team = file.meet.last_team
+        self.assertEqual("Another Person", team.contact_name_2)
+
+    def test_contact_name_1_and_2_identical(self):
+        """Contact names are often identical — both should be populated."""
+        file, opts = self._file()
+        c1 = _make_c1(contact1="Same Person", contact2="Same Person")
+        file = c1_parser(c1, file, opts)
+        _, team = file.meet.last_team
+        self.assertEqual("Same Person", team.contact_name_1)
+        self.assertEqual("Same Person", team.contact_name_2)
+
+    def test_blank_contact_1_is_none(self):
+        """Blank contact_name_1 slot → None."""
+        file, opts = self._file()
+        c1 = _make_c1(contact1="", contact2="")
+        file = c1_parser(c1, file, opts)
+        _, team = file.meet.last_team
+        self.assertIsNone(team.contact_name_1)
+
+    def test_blank_contact_2_is_none(self):
+        """Blank contact_name_2 slot → None even when contact_name_1 is set."""
+        file, opts = self._file()
+        c1 = _make_c1(contact1="Test Contact", contact2="")
+        file = c1_parser(c1, file, opts)
+        _, team = file.meet.last_team
+        self.assertIsNone(team.contact_name_2)
 
 
 if __name__ == "__main__":

--- a/tests/hy3/line_parsers/test_c_team_parsers.py
+++ b/tests/hy3/line_parsers/test_c_team_parsers.py
@@ -1,0 +1,35 @@
+import unittest
+from hytek_parser.hy3.schemas import ParsedHytekFile, Meet
+from hytek_parser.hy3.line_parsers.c_team_parsers import c1_parser
+
+
+class TestC1TeamRegion(unittest.TestCase):
+    """Issue #118 — populate Team.region from the C1 LSC code at cols 54-56."""
+
+    def _file(self):
+        file = ParsedHytekFile()
+        file.meet = Meet()
+        return file, {"default_country": "USA"}
+
+    def test_c1_region_from_col_54(self):
+        file, opts = self._file()
+        # Real C1 shape: code(3-7), name(8-37), short(38-53), LSC(54-56).
+        c1 = "C1ANA  Andover/North Andover YMCA    Andover-MA      NE                                                               0  0      27"
+        self.assertEqual(130, len(c1))
+        file = c1_parser(c1, file, opts)
+        _, team = file.meet.last_team
+        self.assertEqual("ANA", team.code)
+        self.assertEqual("NE", team.region)
+
+    def test_c1_blank_region_is_none(self):
+        file, opts = self._file()
+        # Same shape, LSC columns blank
+        c1 = "C1AMFY AuglaizeMercer YMCA          AuglaizeMercerOH                                                                  0  0      27"
+        self.assertEqual(130, len(c1))
+        file = c1_parser(c1, file, opts)
+        _, team = file.meet.last_team
+        self.assertIsNone(team.region)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hy3/line_parsers/test_d_swimmer_parsers.py
+++ b/tests/hy3/line_parsers/test_d_swimmer_parsers.py
@@ -38,7 +38,7 @@ class TestDSwimmerParser(unittest.TestCase):
             self.assertIsNone(swimmer.team_id)
 
 class TestD1NewFields(unittest.TestCase):
-    """Issue #118 — capture D1 citizenship (cols 113-115) and unparsed col 125."""
+    """capture D1 citizenship (cols 113-115) and unparsed col 125."""
 
     def _file_with_team(self):
         opts = {"default_country": "USA"}

--- a/tests/hy3/line_parsers/test_d_swimmer_parsers.py
+++ b/tests/hy3/line_parsers/test_d_swimmer_parsers.py
@@ -37,6 +37,37 @@ class TestDSwimmerParser(unittest.TestCase):
             self.assertIsNone(swimmer.date_of_birth)
             self.assertIsNone(swimmer.team_id)
 
-if __name__=='__main__':
-	unittest.main()
- 
+class TestD1NewFields(unittest.TestCase):
+    """Issue #118 — capture D1 citizenship (cols 113-115) and unparsed col 125."""
+
+    def _file_with_team(self):
+        opts = {"default_country": "USA"}
+        file = ParsedHytekFile()
+        file.meet = Meet()
+        file.meet.last_team = (
+            "FOO",
+            Team("Foo Bar", "FOO", "FOO", "", "", "", "", "", "", "", "", "", "", "", {}),
+        )
+        return file, opts
+
+    def test_d1_citizenship_USA(self):
+        file, opts = self._file_with_team()
+        d1 = "D1M   42Hayon               Gabrielle           Gabby               B           123     11202001  9             USA         N   99"
+        self.assertEqual(130, len(d1))
+        file = d1_parser(d1, file, opts)
+        swimmer = file.meet.swimmers[42]
+        self.assertEqual("USA", swimmer.citizenship)
+        self.assertEqual("N", swimmer.unparsed_d1_col_125)
+
+    def test_d1_blank_citizenship_and_col_125(self):
+        file, opts = self._file_with_team()
+        d1 = "D1M   42Hayon               Gabrielle           Gabby               B           123     11202001  9                             99"
+        self.assertEqual(130, len(d1))
+        file = d1_parser(d1, file, opts)
+        swimmer = file.meet.swimmers[42]
+        self.assertIsNone(swimmer.citizenship)
+        self.assertIsNone(swimmer.unparsed_d1_col_125)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hy3/line_parsers/test_e_event_parsers.py
+++ b/tests/hy3/line_parsers/test_e_event_parsers.py
@@ -88,5 +88,71 @@ class TestE1UnparsedCol77_79(unittest.TestCase):
         self.assertIsNone(entry.unparsed_e1_col_77_79)
 
 
+class TestE2BackupTimingFields(unittest.TestCase):
+    """Issue #118 — capture pad, 3 buttons, backup_4, alt_time_code from E2 rows."""
+
+    def _build_file(self):
+        opts = {"default_country": "USA"}
+        file = ParsedHytekFile()
+        file.meet = Meet()
+        file.meet.last_team = (
+            "FOO",
+            Team("Foo Bar", "FOO", "FOO", "", "", "", "", "", "", "", "", "", "", "", {}),
+        )
+        d_line = "D1M   27Hansen              Mads                                                        10272010 13                             27"
+        e1_line = "E1M   27HanseXX    50D 11109  0U  0.00 22X   37.41S   37.41S    0.00    0.00  0NN               N                               70"
+        file = d1_parser(d_line, file, opts)
+        file = e1_parser(e1_line, file, opts)
+        return file, opts
+
+    def test_e2_with_pad_and_buttons_and_alt_code(self):
+        """Allie Cooper failure mode: pad=12.80, buttons=41.16/40.88, alt=K."""
+        file, opts = self._build_file()
+        # 130-char E2 line. Column anchors (1-indexed):
+        #  4-11 time, 12 course, 13 time_code, 21-23 heat, 24-26 lane,
+        #  27-29 heat_place, 30-33 overall_place,
+        #  39-46 button_1, 47-54 button_2, 55-62 button_3,
+        #  63-74 pad, 75-82 backup_4, 88-95 date, 96 alt_code.
+        e2 = "E2F   12.80Y          4  5  1   1   0    41.16   40.88    0.00       12.80    0.00     12012018K                          0     66"
+        self.assertEqual(130, len(e2))
+        file = e2_parser(e2, file, opts)
+        entry = file.meet.events["22X"].last_entry
+        self.assertEqual(12.80, entry.finals_time)
+        self.assertAlmostEqual(12.80, entry.finals_pad_time, places=2)
+        self.assertAlmostEqual(41.16, entry.finals_button_1_time, places=2)
+        self.assertAlmostEqual(40.88, entry.finals_button_2_time, places=2)
+        self.assertIsNone(entry.finals_button_3_time)  # 0.00 → None
+        self.assertIsNone(entry.finals_backup_4_time)
+        self.assertEqual("K", entry.finals_alt_time_code)
+
+    def test_e2_clean_row_with_all_three_buttons(self):
+        """Three populated buttons, blank alt code, clean pad."""
+        file, opts = self._build_file()
+        e2 = "E2F   54.00Y          2  3  2  14   0    54.25   54.22   54.16       54.00    0.00     11202010                           0     66"
+        self.assertEqual(130, len(e2))
+        file = e2_parser(e2, file, opts)
+        entry = file.meet.events["22X"].last_entry
+        self.assertAlmostEqual(54.25, entry.finals_button_1_time, places=2)
+        self.assertAlmostEqual(54.22, entry.finals_button_2_time, places=2)
+        self.assertAlmostEqual(54.16, entry.finals_button_3_time, places=2)
+        self.assertAlmostEqual(54.00, entry.finals_pad_time, places=2)
+        self.assertIsNone(entry.finals_alt_time_code)
+
+    def test_e2_blank_timing_fields_all_none(self):
+        """Hand-timed: no pad/buttons recorded → all six new fields None."""
+        file, opts = self._build_file()
+        e2 = "E2F   54.79Y          2  3  4  12   0     0.00    0.00    0.00        0.00    0.00     12012018                           0     25"
+        self.assertEqual(130, len(e2))
+        file = e2_parser(e2, file, opts)
+        entry = file.meet.events["22X"].last_entry
+        self.assertEqual(54.79, entry.finals_time)
+        self.assertIsNone(entry.finals_pad_time)
+        self.assertIsNone(entry.finals_button_1_time)
+        self.assertIsNone(entry.finals_button_2_time)
+        self.assertIsNone(entry.finals_button_3_time)
+        self.assertIsNone(entry.finals_backup_4_time)
+        self.assertIsNone(entry.finals_alt_time_code)
+
+
 if __name__=='__main__':
     unittest.main()

--- a/tests/hy3/line_parsers/test_e_event_parsers.py
+++ b/tests/hy3/line_parsers/test_e_event_parsers.py
@@ -56,7 +56,7 @@ class TestE2BlankDateColumn(unittest.TestCase):
 
 
 class TestE1MeetDivision(unittest.TestCase):
-    """Issue #118 — capture Meet Division at cols 77-79 (e.g. 'VR', 'JV', 'A'/'AA'/numeric)."""
+    """capture Meet Division at cols 77-79 (e.g. 'VR', 'JV', 'A'/'AA'/numeric)."""
 
     def _build_file(self):
         opts = {"default_country": "USA"}
@@ -100,7 +100,7 @@ class TestE1MeetDivision(unittest.TestCase):
 
 
 class TestE2BackupTimingFields(unittest.TestCase):
-    """Issue #118 — capture pad, 3 buttons, backup_4, alt_time_code from E2 rows."""
+    """capture pad, 3 buttons, backup_4, alt_time_code from E2 rows."""
 
     def _build_file(self):
         opts = {"default_country": "USA"}

--- a/tests/hy3/line_parsers/test_e_event_parsers.py
+++ b/tests/hy3/line_parsers/test_e_event_parsers.py
@@ -55,5 +55,38 @@ class TestE2BlankDateColumn(unittest.TestCase):
         self.assertIsNone(entry.finals_date)
 
 
+class TestE1UnparsedCol77_79(unittest.TestCase):
+    """Issue #118 — capture cols 77-79 (observed: VR, JV, SLV; semantics unverified)."""
+
+    def _build_file(self):
+        opts = {"default_country": "USA"}
+        file = ParsedHytekFile()
+        file.meet = Meet()
+        file.meet.last_team = (
+            "FOO",
+            Team("Foo Bar", "FOO", "FOO", "", "", "", "", "", "", "", "", "", "", "", {}),
+        )
+        d_line = "D1M   27Hansen              Mads                                                        10272010 13                             27"
+        file = d1_parser(d_line, file, opts)
+        return file, opts
+
+    def test_e1_with_VR_in_77_79(self):
+        file, opts = self._build_file()
+        # E1 with 'VR ' at cols 77-79 (1-based); indices [76:79] in the 130-char line.
+        e1 = "E1M   27HanseXX    50D 11109  0U  0.00 22X   37.41S   37.41S    0.00    0.00VR NN               N                               70"
+        self.assertEqual(130, len(e1))
+        file = e1_parser(e1, file, opts)
+        entry = file.meet.events["22X"].last_entry
+        self.assertEqual("VR", entry.unparsed_e1_col_77_79)
+
+    def test_e1_with_blank_77_79(self):
+        file, opts = self._build_file()
+        e1 = "E1M   27HanseXX    50D 11109  0U  0.00 22X   37.41S   37.41S    0.00    0.00   NN               N                               70"
+        self.assertEqual(130, len(e1))
+        file = e1_parser(e1, file, opts)
+        entry = file.meet.events["22X"].last_entry
+        self.assertIsNone(entry.unparsed_e1_col_77_79)
+
+
 if __name__=='__main__':
     unittest.main()

--- a/tests/hy3/line_parsers/test_e_event_parsers.py
+++ b/tests/hy3/line_parsers/test_e_event_parsers.py
@@ -55,8 +55,8 @@ class TestE2BlankDateColumn(unittest.TestCase):
         self.assertIsNone(entry.finals_date)
 
 
-class TestE1UnparsedCol77_79(unittest.TestCase):
-    """Issue #118 — capture cols 77-79 (observed: VR, JV, SLV; semantics unverified)."""
+class TestE1MeetDivision(unittest.TestCase):
+    """Issue #118 — capture Meet Division at cols 77-79 (e.g. 'VR', 'JV', 'A'/'AA'/numeric)."""
 
     def _build_file(self):
         opts = {"default_country": "USA"}
@@ -70,22 +70,22 @@ class TestE1UnparsedCol77_79(unittest.TestCase):
         file = d1_parser(d_line, file, opts)
         return file, opts
 
-    def test_e1_with_VR_in_77_79(self):
+    def test_e1_meet_division_VR(self):
         file, opts = self._build_file()
         # E1 with 'VR ' at cols 77-79 (1-based); indices [76:79] in the 130-char line.
         e1 = "E1M   27HanseXX    50D 11109  0U  0.00 22X   37.41S   37.41S    0.00    0.00VR NN               N                               70"
         self.assertEqual(130, len(e1))
         file = e1_parser(e1, file, opts)
         entry = file.meet.events["22X"].last_entry
-        self.assertEqual("VR", entry.unparsed_e1_col_77_79)
+        self.assertEqual("VR", entry.meet_division)
 
-    def test_e1_with_blank_77_79(self):
+    def test_e1_meet_division_blank(self):
         file, opts = self._build_file()
         e1 = "E1M   27HanseXX    50D 11109  0U  0.00 22X   37.41S   37.41S    0.00    0.00   NN               N                               70"
         self.assertEqual(130, len(e1))
         file = e1_parser(e1, file, opts)
         entry = file.meet.events["22X"].last_entry
-        self.assertIsNone(entry.unparsed_e1_col_77_79)
+        self.assertIsNone(entry.meet_division)
 
 
 class TestE2BackupTimingFields(unittest.TestCase):

--- a/tests/hy3/line_parsers/test_e_event_parsers.py
+++ b/tests/hy3/line_parsers/test_e_event_parsers.py
@@ -153,6 +153,16 @@ class TestE2BackupTimingFields(unittest.TestCase):
         self.assertIsNone(entry.finals_backup_4_time)
         self.assertIsNone(entry.finals_alt_time_code)
 
+    def test_e2_genuinely_blank_button_field_is_none(self):
+        """A blank (all-spaces) button field must yield None, not a time code enum."""
+        file, opts = self._build_file()
+        # button_1 (cols 39-46, 0-indexed [38:46]) left blank/spaces instead of 0.00
+        e2 = "E2F   54.79Y          2  3  4  12   0             0.00    0.00        0.00    0.00     12012018                           0     25"
+        self.assertEqual(130, len(e2))
+        file = e2_parser(e2, file, opts)
+        entry = file.meet.events["22X"].last_entry
+        self.assertIsNone(entry.finals_button_1_time)
+
 
 if __name__=='__main__':
     unittest.main()

--- a/tests/hy3/line_parsers/test_e_event_parsers.py
+++ b/tests/hy3/line_parsers/test_e_event_parsers.py
@@ -87,6 +87,17 @@ class TestE1MeetDivision(unittest.TestCase):
         entry = file.meet.events["22X"].last_entry
         self.assertIsNone(entry.meet_division)
 
+    def test_e1_meet_division_col92_fallback(self):
+        """MM4/MM5-7.0Fa store the division at cols 92-93 (col 77-79 blank).
+        meet_division must fall back to col 92."""
+        file, opts = self._build_file()
+        # 130-char line: col 77-79 (indices [76:79]) is blank, col 92-93 (indices [91:93]) = 'SW'
+        e1 = "E1M   27HanseXX    50D 11109  0U  0.00 22X   37.41S   37.41S    0.00    0.00   NN          SW   N                               70"
+        self.assertEqual(130, len(e1))
+        file = e1_parser(e1, file, opts)
+        entry = file.meet.events["22X"].last_entry
+        self.assertEqual("SW", entry.meet_division)
+
 
 class TestE2BackupTimingFields(unittest.TestCase):
     """Issue #118 — capture pad, 3 buttons, backup_4, alt_time_code from E2 rows."""

--- a/tests/hy3/line_parsers/test_event_entry_schema.py
+++ b/tests/hy3/line_parsers/test_event_entry_schema.py
@@ -5,7 +5,7 @@ from hytek_parser.hy3.enums import Course
 
 class TestEventEntryNewTimingFields(unittest.TestCase):
     """Issue #118 — EventEntry gains 19 new attributes (18 timing × 3 prefixes
-    + 1 entry-level unparsed_e1_col_77_79)."""
+    + 1 entry-level meet_division)."""
 
     def _make_entry(self):
         return EventEntry(
@@ -35,10 +35,10 @@ class TestEventEntryNewTimingFields(unittest.TestCase):
                     f"{attr} should default to None",
                 )
 
-    def test_unparsed_e1_col_77_79_defaults_to_none(self):
+    def test_meet_division_defaults_to_none(self):
         entry = self._make_entry()
-        self.assertTrue(hasattr(entry, "unparsed_e1_col_77_79"))
-        self.assertIsNone(entry.unparsed_e1_col_77_79)
+        self.assertTrue(hasattr(entry, "meet_division"))
+        self.assertIsNone(entry.meet_division)
 
 
 if __name__ == "__main__":

--- a/tests/hy3/line_parsers/test_event_entry_schema.py
+++ b/tests/hy3/line_parsers/test_event_entry_schema.py
@@ -1,0 +1,45 @@
+import unittest
+from hytek_parser.hy3.schemas import EventEntry
+from hytek_parser.hy3.enums import Course
+
+
+class TestEventEntryNewTimingFields(unittest.TestCase):
+    """Issue #118 — EventEntry gains 19 new attributes (18 timing × 3 prefixes
+    + 1 entry-level unparsed_e1_col_77_79)."""
+
+    def _make_entry(self):
+        return EventEntry(
+            swimmers={},
+            relay=False,
+            event_number="22X",
+            seed_time=0.0,
+            seed_course=Course.SCY,
+            converted_seed_time=0.0,
+            converted_seed_time_course=Course.SCY,
+        )
+
+    def test_all_18_timing_fields_default_to_none(self):
+        entry = self._make_entry()
+        for prefix in ("prelim", "swimoff", "finals"):
+            for field in (
+                "pad_time", "button_1_time", "button_2_time",
+                "button_3_time", "backup_4_time", "alt_time_code",
+            ):
+                attr = f"{prefix}_{field}"
+                self.assertTrue(
+                    hasattr(entry, attr),
+                    f"EventEntry missing attr {attr}",
+                )
+                self.assertIsNone(
+                    getattr(entry, attr),
+                    f"{attr} should default to None",
+                )
+
+    def test_unparsed_e1_col_77_79_defaults_to_none(self):
+        entry = self._make_entry()
+        self.assertTrue(hasattr(entry, "unparsed_e1_col_77_79"))
+        self.assertIsNone(entry.unparsed_e1_col_77_79)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hy3/line_parsers/test_event_entry_schema.py
+++ b/tests/hy3/line_parsers/test_event_entry_schema.py
@@ -4,7 +4,7 @@ from hytek_parser.hy3.enums import Course
 
 
 class TestEventEntryNewTimingFields(unittest.TestCase):
-    """Issue #118 — EventEntry gains 19 new attributes (18 timing × 3 prefixes
+    """EventEntry gains 19 new attributes (18 timing × 3 prefixes
     + 1 entry-level meet_division)."""
 
     def _make_entry(self):

--- a/tests/hy3/line_parsers/test_f_relay_parsers.py
+++ b/tests/hy3/line_parsers/test_f_relay_parsers.py
@@ -135,5 +135,55 @@ class TestF3DictKeyedSwimmers(unittest.TestCase):
         self.assertEqual(set(entry.swimmers.keys()), {1, 2, 3, 4, 5, 6, 7, 8})
 
 
+class TestF2BackupTimingFields(unittest.TestCase):
+    """Issue #118 — F2 timing fields. Same offsets as E2 for the five timing
+    columns; alt_time_code at col 111 (NOT 96) because F2's date is at col 103."""
+
+    def _build_file_with_relay_entry(self):
+        opts = {"default_country": "USA"}
+        file = ParsedHytekFile()
+        file.meet = Meet()
+        file.meet.last_team = (
+            "FOO",
+            Team("Foo Bar", "FOO", "FOO", "", "", "", "", "", "", "", "", "", "", "", {}),
+        )
+        f1_line = "F1FOO  A   0FFG   200E  0109  0S 30.00  2   112.37Y  112.37Y   52.00    0.00   NN   4           NA                              29"
+        file = f1_parser(f1_line, file, opts)
+        return file, opts
+
+    def test_f2_with_buttons_and_alt_code_at_col_111(self):
+        file, opts = self._build_file_with_relay_entry()
+        # F2 with pad+buttons populated and 'A' alt-code at col 111. F2 date at cols 103-110.
+        # Verified offsets: button_1(39-46)=108.20, button_2(47-54)=108.10,
+        # button_3(55-62)=0.00, pad(63-74)=108.15, backup_4(75-82)=0.00,
+        # date(103-110)=02012025, alt_code(111)=A
+        f2_line = "F2F  108.15Y        0  2  6  4   4  0   108.20  108.10    0.00      108.15    0.00                    02012025A                 46"
+        file = f2_parser(f2_line, file, opts)
+        event = file.meet.events[list(file.meet.events.keys())[0]]
+        entry = event.last_entry
+        self.assertAlmostEqual(108.15, entry.finals_time, places=2)
+        self.assertAlmostEqual(108.20, entry.finals_button_1_time, places=2)
+        self.assertAlmostEqual(108.10, entry.finals_button_2_time, places=2)
+        self.assertIsNone(entry.finals_button_3_time)   # 0.00 → None
+        self.assertAlmostEqual(108.15, entry.finals_pad_time, places=2)
+        self.assertIsNone(entry.finals_backup_4_time)   # 0.00 → None
+        self.assertEqual("A", entry.finals_alt_time_code)
+
+    def test_f2_blank_alt_code(self):
+        file, opts = self._build_file_with_relay_entry()
+        # F2 with blank alt_code at col 111 — should surface as None
+        # Verified offsets: button_1(39-46)=111.00, button_2(47-54)=111.16,
+        # pad(63-74)=111.06, date(103-110)=02012025, alt_code(111)=blank
+        f2_line = "F2F  111.06Y        0  2  6  4   4  0   111.00  111.16    0.00      111.06    0.00                    02012025                  46"
+        file = f2_parser(f2_line, file, opts)
+        event = file.meet.events[list(file.meet.events.keys())[0]]
+        entry = event.last_entry
+        self.assertAlmostEqual(111.06, entry.finals_time, places=2)
+        self.assertAlmostEqual(111.00, entry.finals_button_1_time, places=2)
+        self.assertAlmostEqual(111.16, entry.finals_button_2_time, places=2)
+        self.assertAlmostEqual(111.06, entry.finals_pad_time, places=2)
+        self.assertIsNone(entry.finals_alt_time_code)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/hy3/line_parsers/test_f_relay_parsers.py
+++ b/tests/hy3/line_parsers/test_f_relay_parsers.py
@@ -136,7 +136,7 @@ class TestF3DictKeyedSwimmers(unittest.TestCase):
 
 
 class TestF2BackupTimingFields(unittest.TestCase):
-    """Issue #118 — F2 timing fields. Same offsets as E2 for the five timing
+    """F2 timing fields. Same offsets as E2 for the five timing
     columns; alt_time_code at col 111 (NOT 96) because F2's date is at col 103."""
 
     def _build_file_with_relay_entry(self):

--- a/tests/hy3/line_parsers/test_schemas.py
+++ b/tests/hy3/line_parsers/test_schemas.py
@@ -25,6 +25,8 @@ def _swimmer(meet_id: int, last_name: str = "Smith") -> Swimmer:
     s.team_code = "FOO"
     s.date_of_birth = None
     s.age = 12
+    s.citizenship = None
+    s.unparsed_d1_col_125 = None
     return s
 
 

--- a/tests/hy3/test_integration.py
+++ b/tests/hy3/test_integration.py
@@ -158,7 +158,7 @@ def _all_entries(meet, relay_only: bool = False, individual_only: bool = False):
 
 
 class TestMM4Col92DivisionCitizenshipTiming(unittest.TestCase):
-    """MM4 4.0Ec (2013 YMCA Nationals) — issue-#118 col-92 fields.
+    """MM4 4.0Ec (2013 YMCA Nationals) — col-92 fields.
 
     Verifies:
       - Team regions parsed from LSC code (col-92 fallback path)
@@ -230,7 +230,7 @@ class TestMM4Col92DivisionCitizenshipTiming(unittest.TestCase):
 
 
 class TestMM5Col77DivisionAltCodeDivergence(unittest.TestCase):
-    """MM5 6.0Cc (2015 WI State/Non-State Open) — issue-#118 col-77 fields.
+    """MM5 6.0Cc (2015 WI State/Non-State Open) — col-77 fields.
 
     Verifies:
       - Team region 'WI' (Wisconsin Swimming LSC; 2-char, cols 54-55)
@@ -295,7 +295,7 @@ class TestMM5Col77DivisionAltCodeDivergence(unittest.TestCase):
 
 
 class TestMM5PadButtonDivergenceMultiRegion(unittest.TestCase):
-    """MM5 8.0Fd (2025 MT HOT Tropical) — issue-#118 pad-vs-button divergence.
+    """MM5 8.0Fd (2025 MT HOT Tropical) — pad-vs-button divergence.
 
     Verifies:
       - Team regions MT and WY both present

--- a/tests/hy3/test_integration.py
+++ b/tests/hy3/test_integration.py
@@ -141,5 +141,215 @@ class TestMM5RelayAlternates(unittest.TestCase):
             )
 
 
+def _slot_field(entry, slot: str, field: str):
+    """Return ``{slot}_{field}`` from an entry object."""
+    return getattr(entry, f"{slot}_{field}", None)
+
+
+def _all_entries(meet, relay_only: bool = False, individual_only: bool = False):
+    """Yield (event, entry) pairs across all events and entries."""
+    for ev in meet.events.values():
+        if relay_only and not ev.relay:
+            continue
+        if individual_only and ev.relay:
+            continue
+        for e in ev.entries:
+            yield ev, e
+
+
+class TestMM4Col92DivisionCitizenshipTiming(unittest.TestCase):
+    """MM4 4.0Ec (2013 YMCA Nationals) — issue-#118 col-92 fields.
+
+    Verifies:
+      - Team regions parsed from LSC code (col-92 fallback path)
+      - Swimmer citizenship
+      - meet_division 'SW' read via col-92 fallback
+      - E2/F2 pad and button_1 times on individual entries
+      - Relay entry prelim pad + button times
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.parsed = parse_hy3(
+            str(FIXTURE_DIR / "mm4_ymca_col92_division_citizenship.hy3")
+        )
+        cls.meet = cls.parsed.meet
+
+    def test_team_regions_md_ne_ni(self) -> None:
+        regions = {t.region for t in self.meet.teams.values() if t.region}
+        self.assertIn("MD", regions)
+        self.assertIn("NE", regions)
+        self.assertIn("NI", regions)
+
+    def test_at_least_one_swimmer_citizenship_usa(self) -> None:
+        citizenships = {
+            s.citizenship
+            for t in self.meet.teams.values()
+            for s in t.swimmers.values()
+        }
+        self.assertIn("USA", citizenships)
+
+    def test_meet_division_sw_col92_fallback(self) -> None:
+        """At least one entry carries meet_division='SW' — proves col-92 read."""
+        divisions = {
+            e.meet_division for _ev, e in _all_entries(self.meet)
+        }
+        self.assertIn("SW", divisions)
+
+    def test_individual_entry_has_pad_and_button_1_times(self) -> None:
+        with_pad_and_btn = [
+            e
+            for _ev, e in _all_entries(self.meet, individual_only=True)
+            for slot in ("prelim", "swimoff", "finals")
+            if _slot_field(e, slot, "pad_time") is not None
+            and _slot_field(e, slot, "button_1_time") is not None
+        ]
+        self.assertGreater(
+            len(with_pad_and_btn),
+            0,
+            "no individual entry found with both pad_time and button_1_time",
+        )
+
+    def test_relay_entry_prelim_pad_and_button_times(self) -> None:
+        """Relay entry has non-None prelim pad ≈ 111.38 and button_1 ≈ 111.33."""
+        relay_entries = [
+            e for _ev, e in _all_entries(self.meet, relay_only=True)
+        ]
+        self.assertGreater(len(relay_entries), 0, "no relay entries found")
+        entry = relay_entries[0]
+        self.assertIsNotNone(entry.prelim_pad_time, "relay prelim_pad_time is None")
+        self.assertIsNotNone(
+            entry.prelim_button_1_time, "relay prelim_button_1_time is None"
+        )
+        self.assertAlmostEqual(entry.prelim_pad_time, 111.38, places=2)
+        self.assertAlmostEqual(entry.prelim_button_1_time, 111.33, places=2)
+        self.assertIsNotNone(
+            entry.prelim_button_2_time, "relay prelim_button_2_time is None"
+        )
+        self.assertAlmostEqual(entry.prelim_button_2_time, 111.36, places=2)
+
+
+class TestMM5Col77DivisionAltCodeDivergence(unittest.TestCase):
+    """MM5 6.0Cc (2015 WI State/Non-State Open) — issue-#118 col-77 fields.
+
+    Verifies:
+      - Team region 'WIP'
+      - meet_division 'JV' read via col-77 primary path
+      - finals_alt_time_code values 'A' and 'K' present
+      - Pad-vs-button divergence entry (pad > button due to touchpad error)
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.parsed = parse_hy3(str(FIXTURE_DIR / "mm_col77_division.hy3"))
+        cls.meet = cls.parsed.meet
+
+    def test_team_region_wip(self) -> None:
+        regions = {t.region for t in self.meet.teams.values() if t.region}
+        self.assertIn("WIP", regions)
+
+    def test_at_least_one_swimmer_citizenship_usa(self) -> None:
+        citizenships = {
+            s.citizenship
+            for t in self.meet.teams.values()
+            for s in t.swimmers.values()
+        }
+        self.assertIn("USA", citizenships)
+
+    def test_meet_division_jv_col77_primary(self) -> None:
+        """At least one entry carries meet_division='JV' — proves col-77 primary path."""
+        divisions = {e.meet_division for _ev, e in _all_entries(self.meet)}
+        self.assertIn("JV", divisions)
+
+    def test_alt_time_codes_a_and_k_present(self) -> None:
+        """Both 'A' and 'K' must appear across all slot alt_time_code fields."""
+        alt_codes: set = set()
+        for _ev, e in _all_entries(self.meet):
+            for slot in ("prelim", "swimoff", "finals"):
+                code = _slot_field(e, slot, "alt_time_code")
+                if code is not None:
+                    alt_codes.add(code)
+        self.assertIn("A", alt_codes)
+        self.assertIn("K", alt_codes)
+
+    def test_divergence_entry_pad_above_button_1(self) -> None:
+        """The divergence entry has pad_time (107.39) meaningfully above button_1_time (102.49)."""
+        divergence_entries = [
+            (_slot_field(e, slot, "pad_time"), _slot_field(e, slot, "button_1_time"))
+            for _ev, e in _all_entries(self.meet)
+            for slot in ("prelim", "swimoff", "finals")
+            if _slot_field(e, slot, "pad_time") is not None
+            and _slot_field(e, slot, "button_1_time") is not None
+            and _slot_field(e, slot, "pad_time") > _slot_field(e, slot, "button_1_time") + 1.0
+        ]
+        self.assertGreater(
+            len(divergence_entries),
+            0,
+            "no entry found where pad_time exceeds button_1_time by >1 second",
+        )
+        pad, btn1 = divergence_entries[0]
+        self.assertAlmostEqual(pad, 107.39, places=2)
+        self.assertAlmostEqual(btn1, 102.49, places=2)
+
+
+class TestMM5PadButtonDivergenceMultiRegion(unittest.TestCase):
+    """MM5 8.0Fd (2025 MT HOT Tropical) — issue-#118 pad-vs-button divergence.
+
+    Verifies:
+      - Team regions MT and WY both present
+      - Swimmer citizenship USA
+      - finals_alt_time_code 'A' present
+      - Divergence entry: pad_time roughly half of button_1_time (touchpad misattribution)
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.parsed = parse_hy3(
+            str(FIXTURE_DIR / "mm_pad_button_divergence.hy3")
+        )
+        cls.meet = cls.parsed.meet
+
+    def test_team_regions_mt_and_wy(self) -> None:
+        regions = {t.region for t in self.meet.teams.values() if t.region}
+        self.assertIn("MT", regions)
+        self.assertIn("WY", regions)
+
+    def test_at_least_one_swimmer_citizenship_usa(self) -> None:
+        citizenships = {
+            s.citizenship
+            for t in self.meet.teams.values()
+            for s in t.swimmers.values()
+        }
+        self.assertIn("USA", citizenships)
+
+    def test_alt_time_code_a_present(self) -> None:
+        alt_codes: set = set()
+        for _ev, e in _all_entries(self.meet):
+            for slot in ("prelim", "swimoff", "finals"):
+                code = _slot_field(e, slot, "alt_time_code")
+                if code is not None:
+                    alt_codes.add(code)
+        self.assertIn("A", alt_codes)
+
+    def test_divergence_entry_pad_roughly_half_of_button_1(self) -> None:
+        """The divergence entry has pad≈36.26 while button_1≈75.29 (pad < 0.6 * button_1)."""
+        divergence_entries = [
+            (_slot_field(e, slot, "pad_time"), _slot_field(e, slot, "button_1_time"))
+            for _ev, e in _all_entries(self.meet)
+            for slot in ("prelim", "swimoff", "finals")
+            if _slot_field(e, slot, "pad_time") is not None
+            and _slot_field(e, slot, "button_1_time") is not None
+            and _slot_field(e, slot, "pad_time") < 0.6 * _slot_field(e, slot, "button_1_time")
+        ]
+        self.assertGreater(
+            len(divergence_entries),
+            0,
+            "no entry found where pad_time < 0.6 * button_1_time",
+        )
+        pad, btn1 = divergence_entries[0]
+        self.assertAlmostEqual(pad, 36.26, places=2)
+        self.assertAlmostEqual(btn1, 75.29, places=2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/hy3/test_integration.py
+++ b/tests/hy3/test_integration.py
@@ -233,7 +233,7 @@ class TestMM5Col77DivisionAltCodeDivergence(unittest.TestCase):
     """MM5 6.0Cc (2015 WI State/Non-State Open) — issue-#118 col-77 fields.
 
     Verifies:
-      - Team region 'WIP'
+      - Team region 'WI' (Wisconsin Swimming LSC; 2-char, cols 54-55)
       - meet_division 'JV' read via col-77 primary path
       - finals_alt_time_code values 'A' and 'K' present
       - Pad-vs-button divergence entry (pad > button due to touchpad error)
@@ -244,9 +244,11 @@ class TestMM5Col77DivisionAltCodeDivergence(unittest.TestCase):
         cls.parsed = parse_hy3(str(FIXTURE_DIR / "mm_col77_division.hy3"))
         cls.meet = cls.parsed.meet
 
-    def test_team_region_wip(self) -> None:
+    def test_team_region_wi(self) -> None:
+        """Region must be the 2-char LSC code 'WI', not the old buggy 'WIP'."""
         regions = {t.region for t in self.meet.teams.values() if t.region}
-        self.assertIn("WIP", regions)
+        self.assertIn("WI", regions)
+        self.assertNotIn("WIP", regions)
 
     def test_at_least_one_swimmer_citizenship_usa(self) -> None:
         citizenships = {


### PR DESCRIPTION
## Summary

The hy3 parser deliberately drops several positional fields (the `# Skipping over pad/plunger times` blocks, plus a few never-read or mis-read columns on the C1/C2 team records). This PR captures them as **additive, nullable** fields and fixes two column-offset bugs. No breaking changes to existing consumers aside from one documented `Team.region` stub change.

## E2 / F2 result rows — backup timing data (per prelim/swimoff/finals)

The backup-button and touchpad times are the only way to catch primary-time corruption in legacy files. Example failure mode: a 9-year-old's 50 Free SCY exported with a finals time of ~12.8s — physically impossible. The pool was 25 yards (one turn); the touchpad registered the 25-yard **turn-touch** while the three lane backup buttons held the real ~41s finish. With pad/button times dropped, that anomaly is invisible downstream.

Adds, for each result type:
- `pad_time` — cols 63-74
- `button_1_time` / `button_2_time` / `button_3_time` — cols 39-46 / 47-54 / 55-62
- `backup_4_time` — cols 75-82
- `alt_time_code` — col 96 on **E2**, col 111 on **F2** (F2 has a 15-col gap before its date at col 103; confirmed across ~26k F2 rows)

A shared `parse_time_or_none` helper enforces the "`0.00`/blank means not recorded → `None`" convention, since `parse_time` returns `0.0` for `"0.00"` and a `ReplacedTimeTimeCode` for blanks.

## E1 entry rows — Meet Division

- `meet_division` — cols 77-79, with a **col 92-93 fallback** for MM4 / MM5-7.0Fa, which store the same field at a different offset. The two columns are mutually exclusive (verified across a 1M+ row sample), so `extract(77,3) or extract(92,2)` is safe with col-77 precedence. Observed values: `JV`/`VR`, classification codes `A`/`AA`/`AAA`/`BB`, HS enrollment classes `5A`/`4A`, age/level codes `AG`/`SR`, numeric `0`-`3`.

## D1 swimmer rows

- `citizenship` — cols 113-115 (e.g. `USA`, `CAN`, `CHN`)
- `unparsed_d1_col_125` — col 125; semantics unverified, captured raw (see open questions)

## C1 team rows — region/LSC + contact names (resolves `# TODO: Team region`)

- `region` — cols **54-55** (2 chars). The team's LSC code for USA Swimming meets (`NE`/`PC`/`CA`/…), one per team.
- `contact_name_1` — cols 56-85; `contact_name_2` — cols 86-115. The team's contact person name(s) (often identical, sometimes two different people).
- **Behavior note:** `Team.region` default changes from `"Unknown"` to `None`, and its type from `str` to `Optional[str]`. The field was a documented TODO stub never populated with real data, so practical impact should be nil.

## C2 team address rows — two address lines

- The C2 record has **two 30-char address lines**, but they were being read as one merged 60-char `address_1`. Now `address_1` = cols 3-32, `address_2` = cols 33-62 — **populating the existing-but-unused `Team.address_2`** and no longer merging line 1 (often a c/o/attention name) into the street. Line usage is inconsistent across exports (line 1 is sometimes the street with line 2 blank, sometimes a c/o name with the street in line 2), so both are surfaced raw without interpretation.

## Backward compatibility

Every new `EventEntry`, `Swimmer`, and `Team` field is nullable/additive. The only behavior changes are the `Team.region` stub (above) and `Team.address_1` now holding only line 1 (cols 3-32) instead of the merged 60-char blob, with line 2 in the newly-populated `address_2`. I did not bump the version — your call (major, given the region/address_1 semantic changes, or minor treating them as fixes).

## Tests

- Per-parser unit tests for D1, E1, E2, F2, C1 (region width regression + contact names), C2 (two-line split).
- Three PII-redacted integration fixtures spanning MM4 (col-92 division + citizenship + multi-region + C1 contacts), MM5 6.0 (col-77 division + `A`/`K` alt codes), and MM5 8.0 (pad-vs-button divergence), with end-to-end assertions. PII (names/DOBs/IDs, C1 contact names) replaced with same-width placeholders per `tests/hy3/fixtures/README.md`.
- Full suite: **67 passing**.

## Open questions

1. `Team.region` already existed, so I populated it rather than renaming, but its value is specifically the **LSC code** for USA Swimming files. Happy to rename (e.g. `lsc` / `lsc_code`) if you prefer — flagging since that'd be a deliberate breaking change.
2. `unparsed_d1_col_125` (col 125, values `N`/blank) — couldn't determine its meaning, captured under a raw name. Glad to rename if you know what it is.