### PR TITLE
Capture D1 cols 100-101 (school class in HS exports)

### DIFF
--- a/hytek_parser/hy3/line_parsers/d_swimmer_parsers.py
+++ b/hytek_parser/hy3/line_parsers/d_swimmer_parsers.py
@@ -29,6 +29,9 @@ def d1_parser(
     # unparsed_d1_col_125: col 125 (1 char). Observed: 'N' or blank; semantics unverified.
     swimmer.citizenship = extract(line, 113, 3) or None
     swimmer.unparsed_d1_col_125 = extract(line, 125, 1) or None
+    # unparsed_d1_col_100: cols 100-101 (2 chars). "Fr"/"So"/"Jr"/"Sr" school
+    # class in HS-meet exports; other data / blank in club exports.
+    swimmer.unparsed_d1_col_100 = extract(line, 100, 2) or None
 
     swimmer.team_code = team_code
 

--- a/hytek_parser/hy3/line_parsers/d_swimmer_parsers.py
+++ b/hytek_parser/hy3/line_parsers/d_swimmer_parsers.py
@@ -31,7 +31,7 @@ def d1_parser(
     swimmer.unparsed_d1_col_125 = extract(line, 125, 1) or None
     # unparsed_d1_col_100: cols 100-101 (2 chars). "Fr"/"So"/"Jr"/"Sr" school
     # class in HS-meet exports; other data / blank in club exports.
-    swimmer.unparsed_d1_col_100 = extract(line, 100, 2) or None
+    swimmer.class_year = extract(line, 100, 2) or None
 
     swimmer.team_code = team_code
 

--- a/hytek_parser/hy3/line_parsers/d_swimmer_parsers.py
+++ b/hytek_parser/hy3/line_parsers/d_swimmer_parsers.py
@@ -26,9 +26,9 @@ def d1_parser(
 
     # previously dropped D1 fields. Capture both per spec.
     # citizenship: cols 113-115 (3 chars). Observed: 'USA' or blank.
-    # unparsed_d1_col_125: col 125 (1 char). Observed: 'N' or blank; semantics unverified.
+    # status: col 125 (1 char). Athlete status; observed 'N' (Normal) or blank.
     swimmer.citizenship = extract(line, 113, 3) or None
-    swimmer.unparsed_d1_col_125 = extract(line, 125, 1) or None
+    swimmer.status = extract(line, 125, 1) or None
     # class_year: cols 100-101 (2 chars). "Fr"/"So"/"Jr"/"Sr" school
     # class in HS-meet exports; other data / blank in club exports.
     swimmer.class_year = extract(line, 100, 2) or None

--- a/hytek_parser/hy3/line_parsers/d_swimmer_parsers.py
+++ b/hytek_parser/hy3/line_parsers/d_swimmer_parsers.py
@@ -29,7 +29,7 @@ def d1_parser(
     # unparsed_d1_col_125: col 125 (1 char). Observed: 'N' or blank; semantics unverified.
     swimmer.citizenship = extract(line, 113, 3) or None
     swimmer.unparsed_d1_col_125 = extract(line, 125, 1) or None
-    # unparsed_d1_col_100: cols 100-101 (2 chars). "Fr"/"So"/"Jr"/"Sr" school
+    # class_year: cols 100-101 (2 chars). "Fr"/"So"/"Jr"/"Sr" school
     # class in HS-meet exports; other data / blank in club exports.
     swimmer.class_year = extract(line, 100, 2) or None
 

--- a/hytek_parser/hy3/schemas.py
+++ b/hytek_parser/hy3/schemas.py
@@ -40,9 +40,9 @@ class Swimmer:
     citizenship: Optional[str] = None
     # col 125; semantics unverified — name intentionally non-descriptive
     unparsed_d1_col_125: Optional[str] = None
-    # cols 100-101; "Fr"/"So"/"Jr"/"Sr" school class in HS-meet exports, other
-    # data in club exports — name intentionally non-descriptive (consumer interprets)
-    unparsed_d1_col_100: Optional[str] = None
+    # cols 100-101; "Fr"/"So"/"Jr"/"Sr" school class in HS-meet exports,
+    # other data / blank in club exports.
+    class_year: Optional[str] = None
 
 
 @define

--- a/hytek_parser/hy3/schemas.py
+++ b/hytek_parser/hy3/schemas.py
@@ -40,6 +40,9 @@ class Swimmer:
     citizenship: Optional[str] = None
     # col 125; semantics unverified — name intentionally non-descriptive
     unparsed_d1_col_125: Optional[str] = None
+    # cols 100-101; "Fr"/"So"/"Jr"/"Sr" school class in HS-meet exports, other
+    # data in club exports — name intentionally non-descriptive (consumer interprets)
+    unparsed_d1_col_100: Optional[str] = None
 
 
 @define

--- a/hytek_parser/hy3/schemas.py
+++ b/hytek_parser/hy3/schemas.py
@@ -38,8 +38,11 @@ class Swimmer:
 
     # D1 fields previously dropped by the parser
     citizenship: Optional[str] = None
-    # col 125; semantics unverified — name intentionally non-descriptive
-    unparsed_d1_col_125: Optional[str] = None
+    # col 125; athlete status (Hytek MM "Status" field). Raw 1-char code — only
+    # "N" (Normal) or blank observed across ~9.25M records; other GUI statuses
+    # (Impaired/Exhibition/Foreigner/Rookie) never seen in data, so left as a
+    # raw code rather than an enum.
+    status: Optional[str] = None
     # cols 100-101; "Fr"/"So"/"Jr"/"Sr" school class in HS-meet exports,
     # other data / blank in club exports.
     class_year: Optional[str] = None

--- a/tests/hy3/line_parsers/test_d_swimmer_parsers.py
+++ b/tests/hy3/line_parsers/test_d_swimmer_parsers.py
@@ -67,7 +67,7 @@ class TestD1NewFields(unittest.TestCase):
         swimmer = file.meet.swimmers[42]
         self.assertIsNone(swimmer.citizenship)
         self.assertIsNone(swimmer.unparsed_d1_col_125)
-        self.assertIsNone(swimmer.unparsed_d1_col_100)
+        self.assertIsNone(swimmer.class_year)
 
     def test_d1_school_class_col_100(self):
         file, opts = self._file_with_team()
@@ -76,7 +76,7 @@ class TestD1NewFields(unittest.TestCase):
         d1 = base[:99] + "Sr" + base[101:]
         self.assertEqual(130, len(d1))
         file = d1_parser(d1, file, opts)
-        self.assertEqual("Sr", file.meet.swimmers[42].unparsed_d1_col_100)
+        self.assertEqual("Sr", file.meet.swimmers[42].class_year)
 
 
 if __name__ == "__main__":

--- a/tests/hy3/line_parsers/test_d_swimmer_parsers.py
+++ b/tests/hy3/line_parsers/test_d_swimmer_parsers.py
@@ -38,7 +38,7 @@ class TestDSwimmerParser(unittest.TestCase):
             self.assertIsNone(swimmer.team_id)
 
 class TestD1NewFields(unittest.TestCase):
-    """capture D1 citizenship (cols 113-115) and unparsed col 125."""
+    """capture D1 citizenship (cols 113-115), unparsed col 125, and unparsed cols 100-101."""
 
     def _file_with_team(self):
         opts = {"default_country": "USA"}
@@ -67,6 +67,16 @@ class TestD1NewFields(unittest.TestCase):
         swimmer = file.meet.swimmers[42]
         self.assertIsNone(swimmer.citizenship)
         self.assertIsNone(swimmer.unparsed_d1_col_125)
+        self.assertIsNone(swimmer.unparsed_d1_col_100)
+
+    def test_d1_school_class_col_100(self):
+        file, opts = self._file_with_team()
+        base = "D1M   42Hayon               Gabrielle           Gabby               B           123     11202001  9                             99"
+        # Place a school-class token at cols 100-101 (1-indexed) via slicing.
+        d1 = base[:99] + "Sr" + base[101:]
+        self.assertEqual(130, len(d1))
+        file = d1_parser(d1, file, opts)
+        self.assertEqual("Sr", file.meet.swimmers[42].unparsed_d1_col_100)
 
 
 if __name__ == "__main__":

--- a/tests/hy3/line_parsers/test_d_swimmer_parsers.py
+++ b/tests/hy3/line_parsers/test_d_swimmer_parsers.py
@@ -57,16 +57,16 @@ class TestD1NewFields(unittest.TestCase):
         file = d1_parser(d1, file, opts)
         swimmer = file.meet.swimmers[42]
         self.assertEqual("USA", swimmer.citizenship)
-        self.assertEqual("N", swimmer.unparsed_d1_col_125)
+        self.assertEqual("N", swimmer.status)
 
-    def test_d1_blank_citizenship_and_col_125(self):
+    def test_d1_blank_citizenship_and_status(self):
         file, opts = self._file_with_team()
         d1 = "D1M   42Hayon               Gabrielle           Gabby               B           123     11202001  9                             99"
         self.assertEqual(130, len(d1))
         file = d1_parser(d1, file, opts)
         swimmer = file.meet.swimmers[42]
         self.assertIsNone(swimmer.citizenship)
-        self.assertIsNone(swimmer.unparsed_d1_col_125)
+        self.assertIsNone(swimmer.status)
         self.assertIsNone(swimmer.class_year)
 
     def test_d1_school_class_col_100(self):

--- a/tests/hy3/line_parsers/test_schemas.py
+++ b/tests/hy3/line_parsers/test_schemas.py
@@ -26,7 +26,7 @@ def _swimmer(meet_id: int, last_name: str = "Smith") -> Swimmer:
     s.date_of_birth = None
     s.age = 12
     s.citizenship = None
-    s.unparsed_d1_col_125 = None
+    s.status = None
     s.class_year = None
     return s
 

--- a/tests/hy3/line_parsers/test_schemas.py
+++ b/tests/hy3/line_parsers/test_schemas.py
@@ -27,6 +27,7 @@ def _swimmer(meet_id: int, last_name: str = "Smith") -> Swimmer:
     s.age = 12
     s.citizenship = None
     s.unparsed_d1_col_125 = None
+    s.unparsed_d1_col_100 = None
     return s
 
 

--- a/tests/hy3/line_parsers/test_schemas.py
+++ b/tests/hy3/line_parsers/test_schemas.py
@@ -27,7 +27,7 @@ def _swimmer(meet_id: int, last_name: str = "Smith") -> Swimmer:
     s.age = 12
     s.citizenship = None
     s.unparsed_d1_col_125 = None
-    s.unparsed_d1_col_100 = None
+    s.class_year = None
     return s
 
 

--- a/tests/hy3/test_integration.py
+++ b/tests/hy3/test_integration.py
@@ -142,9 +142,9 @@ class TestMM5RelayAlternates(unittest.TestCase):
 
     def test_d1_school_class_captured_cols_100_101(self) -> None:
         # D1 cols 100-101 carry the school class (Fr/So/Jr/Sr) in high-school
-        # exports; surfaced via the neutrally-named unparsed_d1_col_100.
+        # exports; surfaced via the class_year field.
         classes = {
-            (s.unparsed_d1_col_100 or "").strip().title()
+            (s.class_year or "").strip().title()
             for t in self.parsed.meet.teams.values()
             for s in t.swimmers.values()
         }

--- a/tests/hy3/test_integration.py
+++ b/tests/hy3/test_integration.py
@@ -140,6 +140,19 @@ class TestMM5RelayAlternates(unittest.TestCase):
                 f"no alternate legs found: {sorted(entry.swimmers.keys())}",
             )
 
+    def test_d1_school_class_captured_cols_100_101(self) -> None:
+        # D1 cols 100-101 carry the school class (Fr/So/Jr/Sr) in high-school
+        # exports; surfaced via the neutrally-named unparsed_d1_col_100.
+        classes = {
+            (s.unparsed_d1_col_100 or "").strip().title()
+            for t in self.parsed.meet.teams.values()
+            for s in t.swimmers.values()
+        }
+        self.assertTrue(
+            classes & {"Fr", "So", "Jr", "Sr"},
+            f"expected at least one Fr/So/Jr/Sr school class, got {sorted(classes)}",
+        )
+
 
 def _slot_field(entry, slot: str, field: str):
     """Return ``{slot}_{field}`` from an entry object."""


### PR DESCRIPTION
## Capture D1 columns 100–101 (`unparsed_d1_col_100`)

Adds capture of the 2-character field at D1 columns 100–101, currently dropped by `d1_parser`.

In **high-school** Hy-Tek meet exports this field holds the swimmer's school class — `Fr`/`So`/`Jr`/`Sr` (case varies across Hy-Tek versions). In club/age-group exports the same columns hold other data or are blank, so — like `unparsed_d1_col_125` — it's surfaced under a deliberately neutral name and left for the consumer to interpret rather than asserting a fixed meaning.

This mirrors the existing `citizenship` / `unparsed_d1_col_125` additions: one field on the `Swimmer` schema plus one `extract(line, 100, 2) or None` line in `d1_parser`. Verified against real high-school result files (the tokens land exactly at cols 100–101 across MM2–MM5 exports).

No behavior change for existing fields; purely additive.
